### PR TITLE
ci: unbreak by aligning Python + HA plugin versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,10 @@ types-requests==2.32.4.20250913
 
 # Testing
 pytest==9.0.0
-pytest-homeassistant-custom-component==0.13.300
+# pytest-homeassistant-custom-component pins homeassistant exactly (and
+# therefore all of HA's transitive deps: aiohttp, aiodns, pycares, etc.).
+# Keep this current with the latest HA to avoid transitive-version drift.
+pytest-homeassistant-custom-component==0.13.324
 pytest-cov==7.0.0
 pytest-asyncio==1.3.0
 pytest-aiohttp==1.1.0
@@ -19,12 +22,12 @@ ruff==0.9.4
 # Mock server dependencies (for running locally outside Docker)
 fastapi==0.115.0
 uvicorn[standard]==0.32.0
-# Loose pin: homeassistant pins requests to a specific patch version that
-# changes across releases; keep this compatible with whatever HA demands.
-requests>=2.32.3
 
-# Home Assistant dependencies
-homeassistant>=2024.11
+# Used directly by config_flow.py, conftest.py, and the mock server.
+# Lower-bound only: homeassistant pins requests to a specific patch version
+# via pytest-homeassistant-custom-component, and that patch changes across HA
+# releases.
+requests>=2.32.3
 
 # Abode library dependencies
 lomond>=0.3.3

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -34,8 +34,9 @@ async def test_change_settings(hass: HomeAssistant, mock_abode) -> None:
     mock_abode.set_setting.assert_called_once()
 
 
-async def test_add_unique_id(hass: HomeAssistant) -> None:
+async def test_add_unique_id(hass: HomeAssistant, mock_abode) -> None:
     """Test unique_id is set to Abode username."""
+    del mock_abode  # Fixture dependency, not used directly
     mock_entry = await setup_platform(hass, ALARM_DOMAIN)
     # Set unique_id to None to match previous config entries
     hass.config_entries.async_update_entry(entry=mock_entry, unique_id=None)


### PR DESCRIPTION
## Summary

CI has been red for months due to accumulated dev-dependency drift. `requirements-dev.txt` pinned `pytest-homeassistant-custom-component==0.13.300` but let `homeassistant>=2024.11` float freely. The plugin pins HA exactly, so the floating bound let pip resolve incompatible transitive versions — most recently an old `pycares` paired with a new `aiodns` that expects `pycares.ares_query_a_result` at module-import time, which crashed every test run.

This PR aligns the whole test stack.

## Changes

**Dev requirements** — `requirements-dev.txt`:
- Bump `pytest-homeassistant-custom-component` to 0.13.324 (latest). Pins `homeassistant==2026.4.3` and a consistent `pycares` / `aiodns` / `aiohttp` set.
- Drop the redundant `homeassistant>=2024.11` line; HA is now sourced transitively from the plugin.
- Rewrite the comment blocks to document the interlocked test stack and clarify that `requests` is a genuine direct dep.

**CI workflows** — `.github/workflows/tests.yaml`, `.github/workflows/validate.yaml`:
- Bump Python matrix from 3.13 to 3.14 (HA 2026.x dropped 3.13; `0.13.324` requires 3.14).
- Bump `actions/setup-python` from v4 to v5 in both workflows to track current action metadata.

**Test fix** — `tests/test_init.py`:
- `test_add_unique_id` was the only test in the file missing the `mock_abode` fixture, so it was hitting the real Abode API during setup. The old plugin silently tolerated this; the new plugin's socket blocker raises `HASocketBlockedError`. Add the fixture.

## Verification

Local fresh-venv run against Python 3.14 + new requirements:

- `ruff check` + `ruff format --check`: clean
- `mypy`: clean
- `pytest`: 117 passed, 121 skipped, 108 deselected — matches prior pass rate

Also builds on two fixes already landed on main: filename typo in `tests.yaml` (requirements_dev.txt → requirements-dev.txt) and loosening the `requests==` pin.

## Test plan

- [x] CI `tests (3.14)` job passes (lint + typecheck + unit)
- [x] CI `frontend-build` job continues to pass (unchanged)
- [x] CI `validate` job continues to pass (unchanged)
