### PR TITLE
fix(socketio): refresh cookies on reconnect; surface persistent disconnect

### DIFF
--- a/custom_components/abode_security/abode/event_controller.py
+++ b/custom_components/abode_security/abode/event_controller.py
@@ -91,6 +91,12 @@ class EventController:
         # Event loop reference for scheduling callbacks
         self._event_loop = None
 
+        # Tracks whether we've handled the very first `started` event. The
+        # synchronous cookie seed is only useful on the first call — on
+        # reconnect the in-memory cookie_jar may be stale and we rely on
+        # _async_get_session() to refresh it.
+        self._initial_seed_done = False
+
         # Setup SocketIO
         self._socketio = sio.SocketIO(url=url, origin=urls.BASE)
 
@@ -98,6 +104,8 @@ class EventController:
         self._socketio.on("started", self._on_socket_started)
         self._socketio.on("connected", self._on_socket_connected)
         self._socketio.on("disconnected", self._on_socket_disconnected)
+        self._socketio.on("persistent_disconnect", self._on_persistent_disconnect)
+        self._socketio.on("connection_recovered", self._on_connection_recovered)
         self._socketio.on("com.goabode.device.update", self._on_device_update)
         self._socketio.on("com.goabode.gateway.mode", self._on_mode_change)
         self._socketio.on("com.goabode.gateway.timeline", self._on_timeline_update)
@@ -277,22 +285,33 @@ class EventController:
             )
             return
 
-        # Schedule async session initialization on the event loop
-        # Seed cookies immediately from current session to avoid races
-        try:
-            session = getattr(self._client, "_session", None)
-            if session is None:
-                log.warning(
-                    "SocketIO started before HTTP session was initialized; "
-                    "proceeding without seed cookies (will fetch via _async_get_session)"
-                )
-            else:
-                cookie_str = _cookie_string(session.cookie_jar)
-                if cookie_str:
-                    self._socketio.set_cookie(cookie_str)
-                    log.debug("Seeded SocketIO cookies from existing session")
-        except Exception as exc:
-            log.debug("Unable to seed cookies from existing session: %s", exc)
+        # Seed cookies from the current session only on the very first
+        # `started` event. On reconnect we must NOT pre-set the cookie:
+        # SocketIO clears self._cookie between iterations, and the wait
+        # loop in _step relies on that to block until _async_get_session()
+        # completes with fresh cookies. Seeding from a possibly-stale
+        # cookie_jar would defeat that wait and reconnect with bad auth.
+        if not self._initial_seed_done:
+            self._initial_seed_done = True
+            try:
+                session = getattr(self._client, "_session", None)
+                if session is None:
+                    log.warning(
+                        "SocketIO started before HTTP session was initialized; "
+                        "proceeding without seed cookies (will fetch via _async_get_session)"
+                    )
+                else:
+                    cookie_str = _cookie_string(session.cookie_jar)
+                    if cookie_str:
+                        self._socketio.set_cookie(cookie_str)
+                        log.debug("Seeded SocketIO cookies from existing session")
+            except Exception as exc:
+                log.debug("Unable to seed cookies from existing session: %s", exc)
+        else:
+            log.debug(
+                "Skipping cookie seed on reconnect; relying on _async_get_session "
+                "to refresh"
+            )
 
         try:
             future = asyncio.run_coroutine_threadsafe(
@@ -405,6 +424,35 @@ class EventController:
             self._connected = False
         with contextlib.suppress(Exception):
             self._client._set_connection_status("disconnected")
+        self._execute_connection_callbacks()
+
+    def _on_persistent_disconnect(self, attempts):
+        """SocketIO failed to reconnect for an extended period.
+
+        Surface this to the client so diagnostics and the HA UI can show that
+        the integration is stuck rather than silently retrying forever.
+        """
+        log.warning(
+            "Abode SocketIO persistently disconnected after %d failed attempts; "
+            "integration may be stuck",
+            attempts,
+        )
+        with self._connection_lock:
+            self._connected = False
+        with contextlib.suppress(Exception):
+            self._client._set_connection_status(
+                "persistent_disconnect",
+                f"SocketIO failed to reconnect after {attempts} attempts",
+            )
+        self._execute_connection_callbacks()
+
+    def _on_connection_recovered(self):
+        """SocketIO reconnected after a previously-emitted persistent disconnect."""
+        log.info("Abode SocketIO reconnected after persistent disconnect")
+        with self._connection_lock:
+            self._connected = True
+        with contextlib.suppress(Exception):
+            self._client._set_connection_status("connected")
         self._execute_connection_callbacks()
 
     def _execute_connection_callbacks(self):

--- a/custom_components/abode_security/abode/socketio.py
+++ b/custom_components/abode_security/abode/socketio.py
@@ -93,6 +93,12 @@ class SocketIO:
         error=4,
     )
 
+    # After this many consecutive failed connect cycles, dispatch a
+    # `persistent_disconnect` event so the outer integration can surface a
+    # warning. With max backoff 30s and min 5s, 20 attempts is ~3.3 to
+    # ~10 minutes of attempts depending on jitter.
+    PERSISTENT_DISCONNECT_THRESHOLD = 20
+
     def __init__(self, url, cookie=None, origin=None):
         params = dict(EIO=3, transport="websocket")
         self._url = url + "?" + urllib.parse.urlencode(params)
@@ -113,6 +119,13 @@ class SocketIO:
 
         self._last_ping_time = datetime.datetime.min
         self._last_packet_time = datetime.datetime.min
+
+        # Reconnect health tracking. _connect_failures increments per
+        # failed iteration of _run and resets to 0 on successful websocket
+        # connect. _persistent_disconnect_fired guards against re-emitting
+        # the same disconnect signal repeatedly while still down.
+        self._connect_failures = 0
+        self._persistent_disconnect_fired = False
 
         self._callbacks = collections.defaultdict(list)
 
@@ -161,9 +174,19 @@ class SocketIO:
         self._running = True
 
         intervals = BackoffIntervals()
+        first_iteration = True
 
         while self._running:
             log.info("Attempting to connect to SocketIO server...")
+
+            # On reconnect, drop any cookie left over from the previous cycle.
+            # The wait-for-cookie poll inside _step then blocks until
+            # _async_get_session() supplies a fresh one — without this the
+            # SocketIO thread would happily reconnect with stale cookies that
+            # Abode invalidated during the disconnect window.
+            if not first_iteration:
+                self._cookie = None
+            first_iteration = False
 
             try:
                 self._step(intervals)
@@ -174,6 +197,21 @@ class SocketIO:
 
             if not self._running:
                 break
+
+            self._connect_failures += 1
+            if (
+                self._connect_failures >= self.PERSISTENT_DISCONNECT_THRESHOLD
+                and not self._persistent_disconnect_fired
+            ):
+                log.warning(
+                    "SocketIO failed to connect %d times consecutively; "
+                    "signaling persistent disconnect",
+                    self._connect_failures,
+                )
+                self._persistent_disconnect_fired = True
+                self._handle_event(
+                    "persistent_disconnect", self._connect_failures
+                )
 
             interval = next(intervals)
             log.info("Waiting %f seconds before reconnecting...", interval)
@@ -252,6 +290,13 @@ class SocketIO:
     def _on_websocket_connected(self, _event):
         self._websocket_connected = True
         log.info("Websocket Connected")
+        # A successful connect clears the persistent-disconnect bookkeeping.
+        # If we'd previously emitted persistent_disconnect, also fire a
+        # recovery event so listeners can clear their warning state.
+        self._connect_failures = 0
+        if self._persistent_disconnect_fired:
+            self._persistent_disconnect_fired = False
+            self._handle_event("connection_recovered")
         self._handle_event("connected")
 
     def _on_websocket_disconnected(self, _event):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,6 +268,15 @@ def pytest_collection_modifyitems(config, items):
         "test_unavailable_to_on_does_not_trigger",
         "test_unknown_to_on_does_not_trigger",
         "test_refire_during_pending_delay_fires_once",
+        # SocketIO reconnect (issue #2)
+        "test_fires_after_threshold_connect_failures",
+        "test_does_not_fire_below_threshold",
+        "test_resets_after_successful_connect_then_refires",
+        "test_websocket_connected_resets_counter",
+        "test_cookie_cleared_before_subsequent_iterations",
+        "test_seeds_only_on_first_started",
+        "test_persistent_disconnect_handler_updates_client_status",
+        "test_connection_recovered_handler_updates_client_status",
     }
     # Skip tests with hass fixture except enabled tests
     for item in items:

--- a/tests/test_socketio_reconnect.py
+++ b/tests/test_socketio_reconnect.py
@@ -1,0 +1,217 @@
+"""SocketIO reconnect behavior: cookie refresh, persistent disconnect surface.
+
+Covers the fixes for issue #2:
+1. Cookies are cleared between reconnect iterations so stale cookies aren't reused.
+2. After PERSISTENT_DISCONNECT_THRESHOLD consecutive failures, a
+   `persistent_disconnect` event is dispatched (once, until next successful connect).
+3. The failure counter resets when the websocket reaches `Connected`.
+4. EventController seeds cookies from the existing session only on the first
+   `started` event; subsequent events skip seeding so the SocketIO wait loop
+   actually blocks on a fresh `_async_get_session()`.
+"""
+
+from unittest.mock import Mock, patch
+
+from custom_components.abode_security.abode import socketio as sio_module
+from custom_components.abode_security.abode.exceptions import SocketIOException
+from custom_components.abode_security.abode.helpers import errors as ERRORS
+from custom_components.abode_security.abode.socketio import SocketIO
+
+
+def _stub_intervals(monkeypatch):
+    """Make BackoffIntervals.__next__ return 0 so _run doesn't sleep."""
+    monkeypatch.setattr(sio_module.BackoffIntervals, "__next__", lambda _self: 0)
+
+
+class TestPersistentDisconnect:
+    """SocketIO surfaces a persistent_disconnect event after N failures."""
+
+    def test_fires_after_threshold_connect_failures(self, monkeypatch):
+        _stub_intervals(monkeypatch)
+        s = SocketIO(url="ws://example/socket.io/", cookie="seed")
+
+        fired = []
+        s.on("persistent_disconnect", lambda count: fired.append(count))
+
+        threshold = SocketIO.PERSISTENT_DISCONNECT_THRESHOLD
+        attempts = {"n": 0}
+
+        def fake_step(_intervals):
+            attempts["n"] += 1
+            # Stop a couple iterations past the threshold so we see one fire.
+            if attempts["n"] >= threshold + 2:
+                s._running = False
+            raise SocketIOException(ERRORS.SOCKETIO_ERROR, details="boom")
+
+        s._step = fake_step  # type: ignore[assignment]
+        s._run()
+
+        assert fired == [threshold], (
+            "persistent_disconnect must fire exactly once after threshold reached, "
+            f"got {fired}"
+        )
+
+    def test_does_not_fire_below_threshold(self, monkeypatch):
+        _stub_intervals(monkeypatch)
+        s = SocketIO(url="ws://example/socket.io/", cookie="seed")
+        fired = []
+        s.on("persistent_disconnect", lambda count: fired.append(count))
+
+        attempts = {"n": 0}
+        # Stop a few iterations short of the threshold.
+        stop_at = SocketIO.PERSISTENT_DISCONNECT_THRESHOLD - 2
+
+        def fake_step(_intervals):
+            attempts["n"] += 1
+            if attempts["n"] >= stop_at:
+                s._running = False
+            raise SocketIOException(ERRORS.SOCKETIO_ERROR, details="boom")
+
+        s._step = fake_step  # type: ignore[assignment]
+        s._run()
+
+        assert fired == []
+
+    def test_resets_after_successful_connect_then_refires(self, monkeypatch):
+        """After a recovery, the threshold counter restarts so a later
+        persistent failure can fire again."""
+        _stub_intervals(monkeypatch)
+        s = SocketIO(url="ws://example/socket.io/", cookie="seed")
+        fired = []
+        recovered = []
+        s.on("persistent_disconnect", lambda count: fired.append(count))
+        s.on("connection_recovered", lambda: recovered.append(True))
+
+        threshold = SocketIO.PERSISTENT_DISCONNECT_THRESHOLD
+        attempts = {"n": 0}
+
+        def fake_step(_intervals):
+            attempts["n"] += 1
+            # Fail enough times to fire persistent_disconnect once.
+            if attempts["n"] == threshold + 2:
+                # Simulate a successful websocket connect: the handler resets
+                # counters and emits connection_recovered.
+                s._on_websocket_connected(Mock())
+            # Then fail again until the threshold trips a second time.
+            if attempts["n"] >= 2 * threshold + 4:
+                s._running = False
+            raise SocketIOException(ERRORS.SOCKETIO_ERROR, details="boom")
+
+        s._step = fake_step  # type: ignore[assignment]
+        s._run()
+
+        assert recovered == [True], "connection_recovered should fire after reset"
+        assert fired == [threshold, threshold], (
+            f"persistent_disconnect should fire twice (once before recovery, "
+            f"once after a second run of failures), got {fired}"
+        )
+
+    def test_websocket_connected_resets_counter(self):
+        s = SocketIO(url="ws://example/socket.io/", cookie="seed")
+        s._connect_failures = 7
+        s._persistent_disconnect_fired = False
+
+        s._on_websocket_connected(Mock())
+
+        assert s._connect_failures == 0
+
+
+class TestCookieClearingBetweenIterations:
+    """Stale cookies are not reused across reconnect attempts."""
+
+    def test_cookie_cleared_before_subsequent_iterations(self, monkeypatch):
+        _stub_intervals(monkeypatch)
+        s = SocketIO(url="ws://example/socket.io/", cookie="initial-cookie")
+
+        seen_cookies = []
+        attempts = {"n": 0}
+
+        def fake_step(_intervals):
+            seen_cookies.append(s._cookie)
+            attempts["n"] += 1
+            if attempts["n"] >= 3:
+                s._running = False
+            raise SocketIOException(ERRORS.SOCKETIO_ERROR, details="boom")
+
+        s._step = fake_step  # type: ignore[assignment]
+        s._run()
+
+        assert seen_cookies[0] == "initial-cookie", "first iteration uses seeded cookie"
+        assert seen_cookies[1:] == [None, None], (
+            "later iterations must clear cookie so the wait loop blocks for fresh ones, "
+            f"got {seen_cookies}"
+        )
+
+
+class TestEventControllerStartedSeeding:
+    """EventController only seeds cookies on the first `started` event.
+
+    On reconnect the in-memory session.cookie_jar may be stale; the SocketIO
+    wait loop must block until _async_get_session() refreshes them.
+    """
+
+    def _make_controller(self):
+        from custom_components.abode_security.abode import event_controller as ec_module
+
+        client = Mock()
+        # Build the controller without touching real network endpoints.
+        # Patch SocketIO so __init__ doesn't try to start anything.
+        with patch.object(ec_module.sio, "SocketIO") as mock_socketio_cls:
+            mock_socketio_cls.return_value = Mock()
+            ec = ec_module.EventController(client=client, url="ws://example/")
+        # A running event loop substitute - just enough to satisfy the guard.
+        loop = Mock()
+        loop.is_running = Mock(return_value=True)
+        ec._event_loop = loop
+        return ec
+
+    def test_seeds_only_on_first_started(self, monkeypatch):
+        ec = self._make_controller()
+
+        fake_session = Mock()
+        # Concrete value isn't used; _cookie_string is monkeypatched below.
+        fake_session.cookie_jar = []
+        from custom_components.abode_security.abode import event_controller as ec_module
+
+        monkeypatch.setattr(ec_module, "_cookie_string", lambda _jar: "seed=value")
+        ec._client._session = fake_session
+
+        # Don't actually schedule anything on the event loop.
+        with patch(
+            "custom_components.abode_security.abode.event_controller.asyncio.run_coroutine_threadsafe"
+        ) as mock_schedule:
+            mock_schedule.return_value = Mock()
+
+            ec._on_socket_started()
+            ec._on_socket_started()
+            ec._on_socket_started()
+
+        set_cookie_calls = ec._socketio.set_cookie.call_args_list
+        # Only the first started call should have seeded the cookie.
+        assert len(set_cookie_calls) == 1, (
+            f"set_cookie should be called once (first started only), "
+            f"got {len(set_cookie_calls)} calls: {set_cookie_calls}"
+        )
+        assert set_cookie_calls[0][0] == ("seed=value",)
+
+    def test_persistent_disconnect_handler_updates_client_status(self):
+        ec = self._make_controller()
+        # Make _set_connection_status track invocations.
+        ec._client._set_connection_status = Mock()
+
+        ec._on_persistent_disconnect(20)
+
+        ec._client._set_connection_status.assert_called_once()
+        args = ec._client._set_connection_status.call_args
+        assert args[0][0] == "persistent_disconnect"
+        assert "20" in (args[0][1] or "")
+
+    def test_connection_recovered_handler_updates_client_status(self):
+        ec = self._make_controller()
+        ec._client._set_connection_status = Mock()
+
+        ec._on_connection_recovered()
+
+        ec._client._set_connection_status.assert_called_once()
+        args = ec._client._set_connection_status.call_args
+        assert args[0][0] == "connected"


### PR DESCRIPTION
## Summary

- SocketIO now clears `self._cookie` between reconnect iterations so the wait-for-cookie loop in `_step` actually blocks until `_async_get_session()` supplies a fresh cookie. EventController only seeds from `session.cookie_jar` on the very first `started` event.
- New `persistent_disconnect` event fires after `PERSISTENT_DISCONNECT_THRESHOLD` (20) consecutive failed reconnect cycles; matching `connection_recovered` event fires when the socket reconnects. EventController routes both into `Client._set_connection_status` and the connection-status callbacks.
- `_consecutive_failures` (renamed `_connect_failures` on SocketIO to disambiguate from `Client._consecutive_failures`) resets on `_on_websocket_connected`.

## Root cause

`_step()` dispatched `started` every iteration, but `_on_socket_started` synchronously seeded the cookie from the (possibly stale) `session.cookie_jar` before the async refresh ran. That seed satisfied the `while not self._cookie:` poll instantly, so the socket reconnected with the stale cookie before the async path could replace it. There was also no surface — the failure counter only reset on `events.Connected`, which never fires when the connect itself fails, leaving the integration silently dead under prolonged outages.

## Test plan

- [x] Added 8 tests in `tests/test_socketio_reconnect.py` (no `hass` fixture; allowlisted in `tests/conftest.py`)
- [x] Verified tests fail without the fix and pass after
- [x] `scripts/check.sh` green: ruff + ruff format + mypy + pytest (125 passed, 121 skipped pre-existing, 0 regressions)

Fixes #2
