### PR TITLE
fix(client): serialize session recreate, drain in-flight requests

### DIFF
--- a/custom_components/abode_security/abode/client.py
+++ b/custom_components/abode_security/abode/client.py
@@ -119,6 +119,31 @@ class Client:
         self._session_created_time: datetime | None = None  # When session was created
         self._session_max_age_seconds = 1800  # Recreate session every 30 minutes (well before 1h 30s server timeout)
 
+        # Session swap synchronization (issue #3). All three are lazily
+        # initialized in `_ensure_session_swap_primitives` because asyncio
+        # primitives must be created on the running event loop.
+        # - _session_swap_lock: serializes concurrent _recreate_session calls.
+        # - _session_ready: cleared while a swap is in progress; new
+        #   _send_request calls wait on it before incrementing inflight.
+        # - _inflight_zero_event: set whenever _inflight_requests == 0 so
+        #   _recreate_session can drain in-flight requests before closing.
+        self._session_swap_lock: asyncio.Lock | None = None
+        self._session_ready: asyncio.Event | None = None
+        self._inflight_zero_event: asyncio.Event | None = None
+        self._inflight_requests = 0
+        # Bumped when a drain timeout forces the in-flight counter to be
+        # reset out from under a hung request. Each request captures the
+        # generation at registration; if the generation has moved by the
+        # time the request's finally runs, its decrement is skipped (the
+        # swap already accounted for it). Without this, a hung request
+        # that eventually completes after a forced reset would decrement
+        # an unrelated request's slot and falsely signal "no in flight."
+        self._session_swap_generation = 0
+        # Drain timeout: don't wait forever on a stuck request before
+        # forcing the swap. Production aiohttp requests should complete
+        # within the per-request 30 s timeout configured below.
+        self._session_drain_timeout = 35.0
+
         # Background task for proactive session monitoring
         self._session_monitor_task: asyncio.Task | None = None
         self._session_monitor_running = False
@@ -270,38 +295,101 @@ class Client:
         log.info("Logout successful")
         self._set_connection_status("disconnected")
 
+    def _ensure_session_swap_primitives(self) -> None:
+        """Lazily create asyncio primitives bound to the running loop."""
+        if self._session_swap_lock is None:
+            self._session_swap_lock = asyncio.Lock()
+        if self._session_ready is None:
+            self._session_ready = asyncio.Event()
+            self._session_ready.set()
+        if self._inflight_zero_event is None:
+            self._inflight_zero_event = asyncio.Event()
+            if self._inflight_requests == 0:
+                self._inflight_zero_event.set()
+
     async def _recreate_session(self):
-        """Recreate aiohttp session to clear stale connections."""
-        log.info("Recreating aiohttp session due to connection issues")
-        self._session_recreate_count += 1
+        """Recreate aiohttp session, draining in-flight requests first.
 
-        if self._session:
+        Concurrent callers serialize on `_session_swap_lock` so two failure
+        paths can't race two `login()` calls. New `_send_request` callers
+        block on `_session_ready` while the swap is in progress, and the
+        existing in-flight requests are drained via `_inflight_zero_event`
+        before the old session is closed (see issue #3).
+        """
+        self._ensure_session_swap_primitives()
+        assert self._session_swap_lock is not None
+        assert self._session_ready is not None
+        assert self._inflight_zero_event is not None
+
+        async with self._session_swap_lock:
+            log.info("Recreating aiohttp session due to connection issues")
+            self._session_recreate_count += 1
+
+            # Block new requests and wait for in-flight ones to finish.
+            self._session_ready.clear()
             try:
-                await self._session.close()
+                try:
+                    await asyncio.wait_for(
+                        self._inflight_zero_event.wait(),
+                        timeout=self._session_drain_timeout,
+                    )
+                except TimeoutError:
+                    log.warning(
+                        "Session drain timed out after %.1fs (%d still in flight)"
+                        " - proceeding with swap anyway",
+                        self._session_drain_timeout,
+                        self._inflight_requests,
+                    )
+                    # Bump the generation so the hung request's eventual
+                    # finally clause won't decrement a slot it no longer
+                    # owns, and clear the counter so a subsequent recreate
+                    # doesn't wait on the orphaned in-flight slot.
+                    self._session_swap_generation += 1
+                    self._inflight_requests = 0
+                    self._inflight_zero_event.set()
+
+                if self._session:
+                    try:
+                        await self._session.close()
+                    except Exception as exc:
+                        log.warning("Error closing old session: %s", exc)
+
+                # Create fresh session
+                timeout = aiohttp.ClientTimeout(total=30, connect=10, sock_read=10)
+                connector = aiohttp.TCPConnector(limit=10, limit_per_host=5)
+                self._session = aiohttp.ClientSession(
+                    timeout=timeout, connector=connector
+                )
+                self._session_created_time = datetime.now()
+
+                # Clear token to force fresh auth
+                self._token = None
+                self._oauth_token = None
+
+                # Clear CMS cache to force fresh fetch after session recreation
+                self._cms_cache = None
+                self._cms_cache_time = None
+
+                # `login()` calls `self._session.post/get` directly, not
+                # `_send_request`, so it doesn't deadlock on the cleared
+                # ready event.
+                await self.login()
+
+                # Reset failure counter on a successful recreate so the
+                # threshold doesn't trip again on the very next failure.
+                self._consecutive_failures = 0
+            finally:
+                # Always re-open the gate, even if login() raised, so that
+                # callers waiting on _session_ready don't stall forever.
+                self._session_ready.set()
+
+            # Sync cookies to SocketIO if available
+            try:
+                await self._sync_socketio_cookies()
             except Exception as exc:
-                log.warning("Error closing old session: %s", exc)
-
-        # Create fresh session
-        timeout = aiohttp.ClientTimeout(total=30, connect=10, sock_read=10)
-        connector = aiohttp.TCPConnector(limit=10, limit_per_host=5)
-        self._session = aiohttp.ClientSession(timeout=timeout, connector=connector)
-        self._session_created_time = datetime.now()
-
-        # Clear token to force fresh auth
-        self._token = None
-        self._oauth_token = None
-
-        # Clear CMS cache to force fresh fetch after session recreation
-        self._cms_cache = None
-        self._cms_cache_time = None
-
-        await self.login()
-
-        # Sync cookies to SocketIO if available
-        try:
-            await self._sync_socketio_cookies()
-        except Exception as exc:
-            log.warning("Failed to sync cookies after session recreation: %s", exc)
+                log.warning(
+                    "Failed to sync cookies after session recreation: %s", exc
+                )
 
     def _start_session_monitor(self):
         """Start background task to monitor session age and recreate proactively."""
@@ -1068,6 +1156,20 @@ class Client:
                 )
                 await self._recreate_session()
 
+        # Block while a session swap is in progress and register this
+        # request with the in-flight counter so `_recreate_session` can
+        # drain (issue #3). asyncio is single-threaded so the counter
+        # updates don't need a lock. The captured generation token is
+        # checked in the finally clause so a forced drain-timeout reset
+        # can't be undone by this request's eventual decrement.
+        self._ensure_session_swap_primitives()
+        assert self._session_ready is not None
+        assert self._inflight_zero_event is not None
+        await self._session_ready.wait()
+        my_swap_generation = self._session_swap_generation
+        self._inflight_requests += 1
+        self._inflight_zero_event.clear()
+
         try:
             url = f"{urls.BASE}{path}"
             log.debug("API Request - method=%s, path=%s, data=%s", method, url, data)
@@ -1149,6 +1251,17 @@ class Client:
             if not raise_on_error:
                 status = getattr(exc, "status", 0) or 0
                 return ResponseWrapper(str(exc), status, {})
+        finally:
+            # Drop in-flight registration so a pending _recreate_session can
+            # observe the drain. Skip the decrement if our slot was already
+            # reset by a drain timeout (generation moved) — otherwise we'd
+            # falsely zero the counter while another request is in flight
+            # against a freshly swapped session.
+            if my_swap_generation == self._session_swap_generation:
+                self._inflight_requests -= 1
+                if self._inflight_requests <= 0:
+                    self._inflight_requests = 0
+                    self._inflight_zero_event.set()
 
         raise Exception(errors.REQUEST)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -277,6 +277,11 @@ def pytest_collection_modifyitems(config, items):
         "test_seeds_only_on_first_started",
         "test_persistent_disconnect_handler_updates_client_status",
         "test_connection_recovered_handler_updates_client_status",
+        # Client session recreation (issue #3)
+        "test_recreate_waits_for_in_flight_request",
+        "test_two_concurrent_recreates_run_one_login_at_a_time",
+        "test_failure_counter_reset_after_recreate",
+        "test_hung_request_finally_skipped_after_generation_bump",
     }
     # Skip tests with hass fixture except enabled tests
     for item in items:

--- a/tests/test_client_session_recreate.py
+++ b/tests/test_client_session_recreate.py
@@ -1,0 +1,249 @@
+"""Client session recreation: drains in-flight requests, serializes recreates.
+
+Covers the fixes for issue #3:
+
+1. ``_recreate_session`` waits for in-flight ``_send_request`` calls to complete
+   before closing the old session. Without the drain, the in-flight request
+   holds a reference to the closed session and aiohttp raises
+   ``ClientConnectionResetError`` (or hangs).
+2. Concurrent ``_recreate_session`` callers serialize on a single lock so that
+   only one ``login()`` runs per swap, instead of two failure paths racing two
+   logins.
+3. ``_consecutive_failures`` is reset to zero on a successful recreate so the
+   threshold doesn't trip again immediately after recovery.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.abode_security.abode.client import Client
+
+
+class _FakeResponse:
+    """Minimal aiohttp.ClientResponse stand-in for tests."""
+
+    def __init__(self):
+        self.status = 200
+        self.headers = {}
+
+    async def json(self):
+        return {"ok": True}
+
+    async def text(self):
+        return '{"ok": true}'
+
+
+class _ControllableRequest:
+    """Async context manager that pauses inside __aenter__ until released."""
+
+    def __init__(self, started: asyncio.Event, release: asyncio.Event):
+        self._started = started
+        self._release = release
+
+    async def __aenter__(self):
+        self._started.set()
+        await self._release.wait()
+        return _FakeResponse()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _build_client() -> Client:
+    """Build a Client without triggering network or session monitor task."""
+    client = Client(username="user@example.com", password="hunter2")
+    client._initialized = True
+    client._token = "fake-token"
+    client._oauth_token = "fake-oauth"
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _stub_sync_socketio_cookies(monkeypatch):
+    """Avoid touching the real EventController/SocketIO during these tests."""
+    monkeypatch.setattr(Client, "_sync_socketio_cookies", AsyncMock())
+
+
+@pytest.fixture(autouse=True)
+def _stub_aiohttp_client_session(monkeypatch):
+    """Replace the aiohttp.ClientSession constructor used inside
+    _recreate_session so tests don't allocate (and leak) a real session."""
+    fake_session_factory = MagicMock(
+        side_effect=lambda *_a, **_kw: MagicMock(close=AsyncMock())
+    )
+    monkeypatch.setattr(
+        "custom_components.abode_security.abode.client.aiohttp.ClientSession",
+        fake_session_factory,
+    )
+
+
+class TestSessionRecreateDrainsInFlightRequests:
+    """``_recreate_session`` must wait for in-flight requests before closing."""
+
+    async def test_recreate_waits_for_in_flight_request(self):
+        client = _build_client()
+
+        request_started = asyncio.Event()
+        release_request = asyncio.Event()
+
+        # Old session: ``get`` returns a context manager that blocks until
+        # ``release_request`` is set. ``close`` records when it ran.
+        old_session = MagicMock()
+        old_session.close = AsyncMock()
+        old_session.get = MagicMock(
+            return_value=_ControllableRequest(request_started, release_request)
+        )
+        client._session = old_session
+
+        with patch.object(client, "login", new=AsyncMock()):
+            request_task = asyncio.create_task(
+                client._send_request("get", "/some/path")
+            )
+            await request_started.wait()
+            assert old_session.close.await_count == 0
+
+            recreate_task = asyncio.create_task(client._recreate_session())
+
+            # Yield several times so recreate has every chance to make
+            # forward progress. With the fix it must block on the drain.
+            for _ in range(10):
+                await asyncio.sleep(0)
+
+            assert not recreate_task.done(), (
+                "_recreate_session completed before in-flight request drained"
+            )
+            assert client._session is old_session, (
+                "session was swapped while a request was in flight"
+            )
+            assert old_session.close.await_count == 0, (
+                "old session was closed while a request was in flight"
+            )
+
+            # Release the in-flight request; recreate should now proceed.
+            release_request.set()
+            await request_task
+            await recreate_task
+
+            assert old_session.close.await_count == 1
+            assert client._session is not old_session
+
+
+class TestConcurrentRecreateSerialized:
+    """Concurrent failure paths must not race two logins."""
+
+    async def test_two_concurrent_recreates_run_one_login_at_a_time(self):
+        client = _build_client()
+        client._consecutive_failures = 5
+
+        client._session = MagicMock()
+        client._session.close = AsyncMock()
+
+        login_release = asyncio.Event()
+        in_login = 0
+        max_in_login = 0
+        login_calls = 0
+
+        async def fake_login(*_args, **_kwargs):
+            nonlocal in_login, max_in_login, login_calls
+            in_login += 1
+            max_in_login = max(max_in_login, in_login)
+            login_calls += 1
+            # Block until the test releases — this forces both recreates to
+            # be observed inside login() simultaneously if they raced.
+            await login_release.wait()
+            in_login -= 1
+
+        with patch.object(client, "login", new=fake_login):
+            t1 = asyncio.create_task(client._recreate_session())
+            t2 = asyncio.create_task(client._recreate_session())
+
+            # Pump the loop so both tasks have a chance to enter login() if
+            # nothing serializes them.
+            for _ in range(20):
+                await asyncio.sleep(0)
+
+            # Without the lock, both recreates have already entered fake_login
+            # and are both blocked on login_release: max_in_login == 2.
+            # With the lock, only one can be inside; the other is queued on
+            # the swap lock: max_in_login == 1.
+            observed_overlap = max_in_login
+
+            # Release everyone and let the tasks drain.
+            login_release.set()
+            await asyncio.gather(t1, t2)
+
+        assert observed_overlap == 1, (
+            f"recreates raced — {observed_overlap} logins observed concurrently"
+        )
+        assert login_calls == 2, (
+            f"expected one login per serialized recreate, got {login_calls}"
+        )
+
+
+class TestRecreateResetsFailureCounter:
+    """Successful recreate clears _consecutive_failures."""
+
+    async def test_failure_counter_reset_after_recreate(self):
+        client = _build_client()
+        client._consecutive_failures = 7
+
+        client._session = MagicMock()
+        client._session.close = AsyncMock()
+
+        with patch.object(client, "login", new=AsyncMock()):
+            await client._recreate_session()
+
+        assert client._consecutive_failures == 0
+
+
+class TestZombieDecrementAfterDrainTimeout:
+    """A hung request that completes after a drain-timeout reset must not
+    decrement an unrelated request's in-flight slot."""
+
+    async def test_hung_request_finally_skipped_after_generation_bump(self):
+        client = _build_client()
+        # Compress the drain timeout so the test runs quickly.
+        client._session_drain_timeout = 0.05
+
+        request_started = asyncio.Event()
+        release_request = asyncio.Event()
+
+        old_session = MagicMock()
+        old_session.close = AsyncMock()
+        old_session.get = MagicMock(
+            return_value=_ControllableRequest(request_started, release_request)
+        )
+        client._session = old_session
+
+        with patch.object(client, "login", new=AsyncMock()):
+            # Start a request that will hang past the drain timeout.
+            hung_task = asyncio.create_task(client._send_request("get", "/hung"))
+            await request_started.wait()
+            assert client._inflight_requests == 1
+
+            # Recreate hits the drain timeout (since we never release the
+            # request). The generation token must bump and the counter
+            # must be cleared.
+            await client._recreate_session()
+            assert client._session is not old_session
+            assert client._inflight_requests == 0
+            assert client._session_swap_generation == 1
+
+            # Simulate a fresh in-flight request against the new session
+            # (we don't run the body — just register the slot the same way
+            # _send_request would, with the post-swap generation).
+            client._inflight_requests = 1
+            client._inflight_zero_event.clear()
+
+            # Now release the hung request. Its captured generation is 0,
+            # current generation is 1, so its finally must NOT decrement.
+            release_request.set()
+            await hung_task
+
+            assert client._inflight_requests == 1, (
+                "hung request decremented an unrelated in-flight slot after"
+                " drain-timeout reset"
+            )
+            assert not client._inflight_zero_event.is_set()


### PR DESCRIPTION
## Summary

- Serialize concurrent `_recreate_session` calls with an `asyncio.Lock` so two failure paths can't race two `login()` calls.
- Drain in-flight `_send_request` calls (with a 35 s timeout and a swap-generation token to neutralize zombie decrements) before closing the old session, eliminating `ClientConnectionResetError`/hangs at the swap boundary.
- Reset `_consecutive_failures = 0` after a successful recreate so the threshold doesn't trip again on the next failure.

## Root cause

`_recreate_session()` did `await self._session.close()` and reassigned `self._session` while in-flight requests were still inside `async with getattr(self._session, method)(...)`. The closed session would surface as `ClientConnectionResetError` or hang. Concurrently, two coroutines that each accumulated `_consecutive_failures >= 3` would both call `_recreate_session()` unserialized, racing two `login()` calls and losing tokens. `_consecutive_failures` was also never reset inside `_recreate_session`, so the threshold tripped immediately again after a successful recreate.

## Fix

`_recreate_session` now:

1. Acquires `_session_swap_lock` (serializes concurrent recreates).
2. Clears `_session_ready` (new `_send_request` calls block at the gate).
3. Awaits `_inflight_zero_event` with a 35 s timeout (drains in-flight requests). On timeout, bumps `_session_swap_generation` and force-resets the counter so subsequent recreates aren't blocked by an orphaned slot.
4. Closes the old session and installs a fresh one.
5. Calls `login()` (which talks to `self._session` directly, not via `_send_request`, so it doesn't deadlock on the gate).
6. Resets `_consecutive_failures = 0`.
7. Sets `_session_ready` (in `finally`, even if `login()` raised).

`_send_request` captures `my_swap_generation` before incrementing the in-flight counter and only decrements in `finally` if the generation hasn't moved — so a hung request whose slot was force-reset by a drain timeout won't zombie-decrement an unrelated request's slot.

## Test plan

- [x] Added `tests/test_client_session_recreate.py` with four async tests:
  - `test_recreate_waits_for_in_flight_request` — recreate blocks while a request is in flight; old session not closed; swap completes after release.
  - `test_two_concurrent_recreates_run_one_login_at_a_time` — concurrent recreates produce one login at a time (no overlap).
  - `test_failure_counter_reset_after_recreate` — `_consecutive_failures` returns to 0.
  - `test_hung_request_finally_skipped_after_generation_bump` — a hung request that completes after a drain-timeout reset does not decrement an unrelated in-flight slot.
- [x] Verified each test fails before the fix and passes after.
- [x] Full test suite green (`./scripts/check.sh`): 129 passed, 121 skipped (per the documented `enabled_tests` allowlist), 108 deselected (integration), no regressions. Lint, format, and mypy all clean.

Fixes #3
