### PR TITLE
fix(config_flow): preserve entry on reauth, abort on username change

### DIFF
--- a/custom_components/abode_security/config_flow.py
+++ b/custom_components/abode_security/config_flow.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 import voluptuous as vol
 from homeassistant.config_entries import (
+    SOURCE_REAUTH,
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
@@ -138,18 +139,26 @@ class AbodeFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     async def _async_create_entry(self) -> ConfigFlowResult:
         """Create the config entry."""
-        config_data = {
-            CONF_USERNAME: self._username,
-            CONF_PASSWORD: self._password,
-            CONF_POLLING: self._polling,
-        }
-        existing_entry = await self.async_set_unique_id(self._username)
+        await self.async_set_unique_id(self._username)
 
-        if existing_entry:
-            return self.async_update_reload_and_abort(existing_entry, data=config_data)
+        if self.source == SOURCE_REAUTH:
+            # Force username stability on reauth: a different login means a
+            # different account, which would orphan the existing entry.
+            self._abort_if_unique_id_mismatch(reason="reauth_wrong_account")
+            # Use data_updates so existing keys (e.g. CONF_POLLING) survive.
+            return self.async_update_reload_and_abort(
+                self._get_reauth_entry(),
+                data_updates={CONF_PASSWORD: cast(str, self._password)},
+            )
 
+        self._abort_if_unique_id_configured()
         return self.async_create_entry(
-            title=cast(str, self._username), data=config_data
+            title=cast(str, self._username),
+            data={
+                CONF_USERNAME: self._username,
+                CONF_PASSWORD: self._password,
+                CONF_POLLING: self._polling,
+            },
         )
 
     async def async_step_user(

--- a/custom_components/abode_security/strings.json
+++ b/custom_components/abode_security/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reauth_wrong_account": "The username does not match the existing entry. Remove the integration and re-add it to use a different Abode account."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/custom_components/abode_security/translations/en.json
+++ b/custom_components/abode_security/translations/en.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "reauth_successful": "Re-authentication successful"
+      "reauth_successful": "Re-authentication successful",
+      "reauth_wrong_account": "The username does not match the existing entry. Remove the integration and re-add it to use a different Abode account."
     },
     "error": {
       "cannot_connect": "Cannot connect to Abode service",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,8 @@ def pytest_collection_modifyitems(config, items):
         "test_user_flow",
         "test_step_mfa",
         "test_step_reauth",
+        "test_step_reauth_username_change_aborts",
+        "test_step_reauth_preserves_polling",
         # Init tests (Phase 4.5.2)
         "test_change_settings",
         "test_add_unique_id",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -183,3 +183,68 @@ async def test_step_reauth(hass: HomeAssistant) -> None:
 
     assert len(hass.config_entries.async_entries()) == 1
     assert entry.data[CONF_PASSWORD] == "new_password"
+
+
+async def test_step_reauth_username_change_aborts(hass: HomeAssistant) -> None:
+    """Reauth with a different username must abort, not create a duplicate entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="alice@example.com",
+        data={CONF_USERNAME: "alice@example.com", CONF_PASSWORD: "password"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch("custom_components.abode_security.abode.client.Client"):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USERNAME: "bob@example.com",
+                CONF_PASSWORD: "new_password",
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_wrong_account"
+
+    # Original entry untouched, no duplicate created.
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].unique_id == "alice@example.com"
+    assert entries[0].data[CONF_USERNAME] == "alice@example.com"
+    assert entries[0].data[CONF_PASSWORD] == "password"
+
+
+async def test_step_reauth_preserves_polling(hass: HomeAssistant) -> None:
+    """Reauth must merge into existing data so CONF_POLLING is not dropped."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user@email.com",
+        data={
+            CONF_USERNAME: "user@email.com",
+            CONF_PASSWORD: "password",
+            CONF_POLLING: True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with patch("custom_components.abode_security.abode.client.Client"):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USERNAME: "user@email.com",
+                CONF_PASSWORD: "new_password",
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_PASSWORD] == "new_password"
+    # CONF_POLLING must survive reauth — the bug overwrote entry.data wholesale.
+    assert entry.data[CONF_POLLING] is True


### PR DESCRIPTION
## Summary

- Branch `_async_create_entry` on `self.source`: reauth path uses `data_updates={CONF_PASSWORD: ...}` so existing entry keys (notably `CONF_POLLING`) survive the merge.
- Reauth now calls `_abort_if_unique_id_mismatch(reason="reauth_wrong_account")`, blocking the username-change path that previously fell through to `async_create_entry` and orphaned the original entry.
- Add `reauth_wrong_account` abort string + English translation.

## Root cause

`_async_create_entry` rebuilt `config_data` and called `async_set_unique_id(self._username)`. When the user kept their username, `existing_entry` was returned and `data=config_data` overwrote entry data wholesale — silently dropping `CONF_POLLING` because `self._polling` is hard-coded `False` in `__init__`. When the user *changed* their username, `async_set_unique_id` returned `None`, and the flow created a duplicate entry instead of updating the original.

The fix follows Option A from the issue (strict mode): force username stability on reauth, and merge updates instead of replacing.

## Test plan

- [x] Added `test_step_reauth_username_change_aborts` — verifies username change aborts with `reauth_wrong_account` and no duplicate entry is created.
- [x] Added `test_step_reauth_preserves_polling` — verifies `CONF_POLLING=True` survives a successful reauth.
- [x] Both tests registered in `tests/conftest.py` `enabled_tests` allowlist (project gotcha — see CLAUDE.md).
- [x] Verified RED → GREEN: tests fail before the fix, pass after.
- [x] `ruff check`, `ruff format --check`, `mypy` clean.
- [x] Full suite: 127 passed, 0 failed.

Fixes #4
