### PR TITLE
fix(__init__): document single-entry contract for hass.data (fixes #5)

### DIFF
--- a/custom_components/abode_security/__init__.py
+++ b/custom_components/abode_security/__init__.py
@@ -195,7 +195,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     loop = asyncio.get_event_loop()
     abode_client.events.set_event_loop(loop)
 
-    # Initialize ActionManager and ConfigStore for WebSocket API
+    # Initialize ActionManager and ConfigStore for WebSocket API.
+    # Note: keys below are domain-scoped (not entry-scoped). Safe only because
+    # manifest.json declares "single_config_entry": true — the framework aborts
+    # any second user/discovery flow with single_instance_allowed before this
+    # runs. If that flag is ever removed, these writes must move to entry.
+    # runtime_data (and storage keys in ActionManager / ConfigStore namespaced
+    # per entry) — see issue #5.
     from .action_manager import ActionManager
     from .action_trigger import ActionTriggerCoordinator
     from .config_store import ConfigStore

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -21,18 +21,26 @@ pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 async def test_one_config_allowed(hass: HomeAssistant) -> None:
-    """Test that only one Abode Security configuration is allowed."""
+    """Test that only one Abode Security configuration is allowed.
+
+    The framework must abort before any login attempt — otherwise the
+    hass.data[DOMAIN][...] writes in async_setup_entry would clobber the
+    existing entry's ActionManager / ConfigStore / coordinator (issue #5).
+    """
     MockConfigEntry(
         domain=DOMAIN,
         data={CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"},
     ).add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    with patch("custom_components.abode_security.abode.client.Client") as mock_client:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+    # No login should be attempted — manifest's single_config_entry contract.
+    mock_client.assert_not_called()
 
 
 async def test_user_flow(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

- Document the single-entry contract that makes `hass.data[DOMAIN][...]` writes in `async_setup_entry` safe.
- Strengthen `test_one_config_allowed` to assert the Abode `Client` is never instantiated when an existing entry blocks a new flow — pins the framework-level abort as a regression contract.

## Root cause

The issue describes a runtime clobber where `hass.data[DOMAIN]["action_manager"]` (and friends) would be overwritten by a second config entry. Investigation shows this can't trigger today: `manifest.json` declares `"single_config_entry": true`, so HA's framework aborts any second user/discovery flow with `single_instance_allowed` *before* `async_setup_entry` runs (verified in `homeassistant/config_entries.py:1460-1477`). Defense-in-depth `_abort_if_unique_id_configured()` was also added in the recent #4 fix.

So the staged changes are deliberately minimal — no behavior change, just lock in the contract:

1. Comment near the writes calling out the invariant and the migration path (`entry.runtime_data` + per-entry storage namespacing) if the manifest flag is ever removed.
2. Test now asserts `mock_client.assert_not_called()` so silently regressing the manifest flag fails the test instead of degrading to a wasted login attempt + lost runtime state.

## Test plan

- [x] Added `mock_client.assert_not_called()` to `test_one_config_allowed` — verifies framework abort short-circuits before login.
- [x] `./scripts/check.sh` passes (ruff + mypy + 131 unit tests, no regressions).

Fixes #5
