### PR TITLE
fix(config_flow): cleanup aiohttp session on every login attempt

### DIFF
--- a/custom_components/abode_security/config_flow.py
+++ b/custom_components/abode_security/config_flow.py
@@ -68,7 +68,8 @@ class AbodeFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         # Import Client inside function so test mocks can intercept it
         from .abode.client import Client as Abode
 
-        errors = {}
+        errors: dict[str, str] = {}
+        abode = None
 
         try:
             abode = Abode(self._username, self._password, False, False, False)
@@ -88,6 +89,7 @@ class AbodeFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
         except AbodeAuthenticationException as ex:
             if ex.errcode == MFA_CODE_REQUIRED[0]:
+                # finally below cleans up this client; MFA step opens a new one.
                 return await self.async_step_mfa()
 
             LOGGER.error("Unable to connect to Abode: %s", ex)
@@ -105,6 +107,14 @@ class AbodeFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             LOGGER.exception("Unexpected exception during Abode login")
             errors = {"base": "unknown"}
 
+        finally:
+            # Always close the aiohttp session opened by the client (issue #6).
+            # async_setup_entry creates a fresh client on entry creation.
+            if abode is not None:
+                result = abode.cleanup()
+                if hasattr(result, "__await__"):
+                    await result
+
         if errors:
             return self.async_show_form(
                 step_id=step_id, data_schema=vol.Schema(self.data_schema), errors=errors
@@ -117,6 +127,7 @@ class AbodeFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         # Import Client inside function so test mocks can intercept it
         from .abode.client import Client as Abode
 
+        abode = None
         try:
             # Create instance to access login method for passing MFA code
             abode = Abode(self._username, self._password, False, False, False)
@@ -134,6 +145,13 @@ class AbodeFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                 data_schema=vol.Schema(self.mfa_data_schema),
                 errors={"base": "invalid_mfa_code"},
             )
+
+        finally:
+            # Always close the aiohttp session opened by the client (issue #6).
+            if abode is not None:
+                result = abode.cleanup()
+                if hasattr(result, "__await__"):
+                    await result
 
         return await self._async_create_entry()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,9 @@ def pytest_collection_modifyitems(config, items):
         "test_step_reauth",
         "test_step_reauth_username_change_aborts",
         "test_step_reauth_preserves_polling",
+        "test_user_flow_cleanup_on_success",
+        "test_user_flow_cleanup_on_login_failure",
+        "test_step_mfa_cleanup",
         # Init tests (Phase 4.5.2)
         "test_change_settings",
         "test_add_unique_id",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -227,6 +227,85 @@ async def test_step_reauth_username_change_aborts(hass: HomeAssistant) -> None:
     assert entries[0].data[CONF_PASSWORD] == "password"
 
 
+async def test_user_flow_cleanup_on_success(hass: HomeAssistant) -> None:
+    """Successful login must cleanup() the Abode client (issue #6)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch("custom_components.abode_security.abode.client.Client") as mock_client:
+        instance = mock_client.return_value
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    instance.cleanup.assert_called_once()
+
+
+async def test_user_flow_cleanup_on_login_failure(hass: HomeAssistant) -> None:
+    """Failed login must still cleanup() the Abode client (issue #6).
+
+    Simulates the realistic leak scenario: the Client instance is created
+    (session opens), then .login() raises — without try/finally the session
+    is orphaned.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch("custom_components.abode_security.abode.client.Client") as mock_client:
+        instance = mock_client.return_value
+        instance.login.side_effect = AbodeAuthenticationException(
+            (HTTPStatus.BAD_REQUEST, "auth error")
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+    instance.cleanup.assert_called_once()
+
+
+async def test_step_mfa_cleanup(hass: HomeAssistant) -> None:
+    """MFA flow must cleanup() each Abode client it creates (issue #6).
+
+    The first client (login that triggers MFA_CODE_REQUIRED) and the second
+    client (MFA code submission) must both be cleaned up.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch("custom_components.abode_security.abode.client.Client") as mock_client:
+        first_instance = mock_client.return_value
+        first_instance.login.side_effect = AbodeAuthenticationException(
+            MFA_CODE_REQUIRED
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "mfa"
+    first_instance.cleanup.assert_called_once()
+
+    with patch(
+        "custom_components.abode_security.abode.client.Client"
+    ) as mock_mfa_client:
+        mfa_instance = mock_mfa_client.return_value
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={"mfa_code": "123456"}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    mfa_instance.cleanup.assert_called_once()
+
+
 async def test_step_reauth_preserves_polling(hass: HomeAssistant) -> None:
     """Reauth must merge into existing data so CONF_POLLING is not dropped."""
     entry = MockConfigEntry(


### PR DESCRIPTION
## Summary

- Wrap `_async_abode_login` and `_async_abode_mfa_login` in try/finally so the Abode client's aiohttp session is cleaned up on every path (success, auth failure, MFA round, unknown error).
- Mirrors the cleanup pattern already used in `__init__.py async_setup_entry`.
- Adds three regression tests covering success, auth-failure, and MFA paths; new test names registered in the `enabled_tests` allowlist.

## Root cause

The Abode client opens an aiohttp session in its constructor / `_async_initialize`. The two config-flow login helpers created a client and never called `cleanup()`, so each login attempt orphaned one session. In long-running Home Assistant instances where users retry login or hit MFA, the process accumulates orphaned sessions indefinitely.

The success path now closes the short-lived flow client; `async_setup_entry` creates a fresh client when the entry is loaded.

## Test plan

- [x] Added three tests reproducing the leak (success, login failure, MFA round) — verified RED before the fix
- [x] All three pass after the fix (GREEN)
- [x] Full local check suite green: ruff, mypy, 134 unit tests passed (`./scripts/check.sh`)

Fixes #6
