### PR TITLE
refactor(switch): dedupe test mode and table-drive CMS-setting switches

### DIFF
--- a/custom_components/abode_security/switch.py
+++ b/custom_components/abode_security/switch.py
@@ -91,19 +91,9 @@ async def async_setup_entry(
         for alarm_type in MANUAL_ALARM_TYPES
     )
 
-    # Add CMS settings switches (wrapper methods handle missing methods gracefully)
-    # Order: Monitoring Active, Test Mode, Send Media, Dispatch Without Verification, Fire, Medical, Police
-    entities.extend(
-        [
-            AbodeMonitoringActiveSwitch(data, alarm),
-            AbodeTestModeSwitch(data, alarm),
-            AbodeSendMediaSwitch(data, alarm),
-            AbodeDispatchWithoutVerificationSwitch(data, alarm),
-            AbodeDispatchFireSwitch(data, alarm),
-            AbodeDispatchMedicalSwitch(data, alarm),
-            AbodeDispatchPoliceSwitch(data, alarm),
-        ]
-    )
+    # CMS settings switches (wrapper methods handle missing methods gracefully).
+    entities.extend(AbodeCMSSettingSwitch(data, alarm, *row) for row in _CMS_SWITCHES)
+    entities.append(AbodeTestModeSwitch(data, alarm))
 
     async_add_entities(entities)
 
@@ -405,7 +395,12 @@ class AbodeManualAlarmSwitch(SwitchEntity):
 
 
 class AbodeCMSSettingSwitch(SwitchEntity):
-    """Base class for CMS configuration switches."""
+    """Base class for CMS configuration switches.
+
+    Also serves as the base for the test-mode switch, which differs only in
+    its support-flag attribute, its unique-id suffix, and a post-update hook
+    that stops polling when test mode auto-disables on its 30-min timeout.
+    """
 
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
@@ -418,6 +413,8 @@ class AbodeCMSSettingSwitch(SwitchEntity):
         icon: str,
         getter_name: str,
         setter_name: str,
+        unique_id_suffix: str | None = None,
+        support_flag: str = "cms_settings_supported",
     ) -> None:
         """Initialize the CMS setting switch."""
         self._data = data
@@ -426,11 +423,14 @@ class AbodeCMSSettingSwitch(SwitchEntity):
         self._attr_icon = icon
         self._getter_name = getter_name
         self._setter_name = setter_name
+        self._support_flag = support_flag
         self._is_on = False
         self._last_state_change: datetime | None = None
         self._error_count = 0
-        # Use alarm device ID and setting name for unique ID
-        self._attr_unique_id = f"{alarm.id}-{getter_name.lower().replace('_', '-')}"
+        # unique_id must stay stable across the issue #7 refactor — explicit
+        # suffix overrides the default getter-derived form.
+        suffix = unique_id_suffix or getter_name.lower().replace("_", "-")
+        self._attr_unique_id = f"{alarm.id}-{suffix}"
         self._attr_available = True
         self._attr_should_poll = False
         self._initial_sync_done = False
@@ -473,7 +473,7 @@ class AbodeCMSSettingSwitch(SwitchEntity):
                 self._attr_should_poll = True
                 self._initial_sync_done = True
         except AbodeException as ex:
-            if not self._data.cms_settings_supported:
+            if not getattr(self._data, self._support_flag):
                 LOGGER.info("%s unsupported; disabling switch", self._attr_name)
                 self._attr_available = False
                 self._attr_should_poll = False
@@ -519,13 +519,14 @@ class AbodeCMSSettingSwitch(SwitchEntity):
                     previous_state,
                     self._is_on,
                 )
+            self._post_update(previous_state, self._is_on)
             # Mark available on successful poll and reset error count
             self._error_count = 0
             if not self._attr_available:
                 self._attr_available = True
                 self.async_write_ha_state()
         except AbodeException as ex:
-            if not self._data.cms_settings_supported:
+            if not getattr(self._data, self._support_flag):
                 LOGGER.info("%s unsupported; disabling switch", self._attr_name)
                 self._attr_available = False
                 self._attr_should_poll = False
@@ -587,236 +588,86 @@ class AbodeCMSSettingSwitch(SwitchEntity):
         self._last_state_change = datetime.now(UTC)
         self.schedule_update_ha_state()
 
+    def _post_update(self, previous: bool, current: bool) -> None:
+        """Hook called inside async_update on a successful poll, before the error counter resets."""
+
     @property
     def is_on(self) -> bool:
         """Return True if the CMS setting is enabled."""
         return self._is_on
 
 
-class AbodeMonitoringActiveSwitch(AbodeCMSSettingSwitch):
-    """Switch for monitoring active CMS setting."""
-
-    def __init__(self, data: AbodeSystem, alarm: Alarm) -> None:
-        """Initialize the monitoring active switch."""
-        super().__init__(
-            data,
-            alarm,
-            name="Monitoring Active",
-            icon="mdi:shield-check",
-            getter_name="get_monitoring_active",
-            setter_name="set_monitoring_active",
-        )
-
-
-class AbodeSendMediaSwitch(AbodeCMSSettingSwitch):
-    """Switch for send media CMS setting."""
-
-    def __init__(self, data: AbodeSystem, alarm: Alarm) -> None:
-        """Initialize the send media switch."""
-        super().__init__(
-            data,
-            alarm,
-            name="Send Media",
-            icon="mdi:camera",
-            getter_name="get_send_media",
-            setter_name="set_send_media",
-        )
-
-
-class AbodeDispatchWithoutVerificationSwitch(AbodeCMSSettingSwitch):
-    """Switch for dispatch without verification CMS setting."""
-
-    def __init__(self, data: AbodeSystem, alarm: Alarm) -> None:
-        """Initialize the dispatch without verification switch."""
-        super().__init__(
-            data,
-            alarm,
-            name="Dispatch Without Verification",
-            icon="mdi:police-badge",
-            getter_name="get_dispatch_without_verification",
-            setter_name="set_dispatch_without_verification",
-        )
+# (display name, icon, getter, setter) for each CMS-setting switch.
+_CMS_SWITCHES: tuple[tuple[str, str, str, str], ...] = (
+    (
+        "Monitoring Active",
+        "mdi:shield-check",
+        "get_monitoring_active",
+        "set_monitoring_active",
+    ),
+    ("Send Media", "mdi:camera", "get_send_media", "set_send_media"),
+    (
+        "Dispatch Without Verification",
+        "mdi:police-badge",
+        "get_dispatch_without_verification",
+        "set_dispatch_without_verification",
+    ),
+    ("Dispatch Fire", "mdi:fire-truck", "get_dispatch_fire", "set_dispatch_fire"),
+    (
+        "Dispatch Medical",
+        "mdi:hospital-box",
+        "get_dispatch_medical",
+        "set_dispatch_medical",
+    ),
+    (
+        "Dispatch Police",
+        "mdi:police-badge",
+        "get_dispatch_police",
+        "set_dispatch_police",
+    ),
+)
 
 
-class AbodeDispatchPoliceSwitch(AbodeCMSSettingSwitch):
-    """Switch for dispatch police CMS setting."""
+class AbodeTestModeSwitch(AbodeCMSSettingSwitch):
+    """A switch for controlling Abode test mode.
 
-    def __init__(self, data: AbodeSystem, alarm: Alarm) -> None:
-        """Initialize the dispatch police switch."""
-        super().__init__(
-            data,
-            alarm,
-            name="Dispatch Police",
-            icon="mdi:police-badge",
-            getter_name="get_dispatch_police",
-            setter_name="set_dispatch_police",
-        )
-
-
-class AbodeDispatchFireSwitch(AbodeCMSSettingSwitch):
-    """Switch for dispatch fire CMS setting."""
-
-    def __init__(self, data: AbodeSystem, alarm: Alarm) -> None:
-        """Initialize the dispatch fire switch."""
-        super().__init__(
-            data,
-            alarm,
-            name="Dispatch Fire",
-            icon="mdi:fire-truck",
-            getter_name="get_dispatch_fire",
-            setter_name="set_dispatch_fire",
-        )
-
-
-class AbodeDispatchMedicalSwitch(AbodeCMSSettingSwitch):
-    """Switch for dispatch medical CMS setting."""
-
-    def __init__(self, data: AbodeSystem, alarm: Alarm) -> None:
-        """Initialize the dispatch medical switch."""
-        super().__init__(
-            data,
-            alarm,
-            name="Dispatch Medical",
-            icon="mdi:hospital-box",
-            getter_name="get_dispatch_medical",
-            setter_name="set_dispatch_medical",
-        )
-
-
-class AbodeTestModeSwitch(SwitchEntity):
-    """A switch for controlling Abode test mode."""
-
-    _attr_has_entity_name = True
-    _attr_name = "Test Mode"
-    _attr_icon = "mdi:test-tube"
-    _attr_entity_category = EntityCategory.CONFIG
+    Differs from a plain CMS-setting switch in two places: it consults the
+    ``test_mode_supported`` flag (CMS-setting support is independent of
+    test-mode support), and it stops polling after the API auto-disables
+    test mode on its 30-minute server-side timeout.
+    """
 
     def __init__(self, data: AbodeSystem, alarm: Alarm) -> None:
         """Initialize the test mode switch."""
-        self._data = data
-        self._alarm = alarm
-        self._is_on = False
-        self._user_enabled = False  # Track if user explicitly enabled test mode
-        self._last_state_change: datetime | None = (
-            None  # Track when state was last changed
+        super().__init__(
+            data,
+            alarm,
+            name="Test Mode",
+            icon="mdi:test-tube",
+            getter_name="get_test_mode",
+            setter_name="set_test_mode",
+            unique_id_suffix="test-mode",
+            support_flag="test_mode_supported",
         )
-        # Use alarm device ID for unique ID to link to the alarm device
-        self._attr_unique_id = f"{alarm.id}-test-mode"
-        self._attr_available = True
-        # Start with polling disabled - will be enabled after first successful fetch
-        # to ensure async_added_to_hass can set initial status before polling starts
-        self._attr_should_poll = False
-        self._initial_sync_done = False
+        self._user_enabled = False
 
-    @property
-    def device_info(self) -> dict[str, Any]:
-        """Return device registry information for this entity."""
-        return {
-            "identifiers": {(DOMAIN, self._alarm.id)},
-            "manufacturer": "Abode",
-            "model": self._alarm.type,
-            "name": self._alarm.name,
-        }
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable test mode and remember the user enabled it."""
+        await super().async_turn_on(**kwargs)
+        # Mirror parent's success signal: _is_on flips True only if the API
+        # call didn't raise (handle_abode_errors swallows AbodeError).
+        if self._is_on:
+            self._user_enabled = True
 
-    async def async_added_to_hass(self) -> None:
-        """Update test mode status on first add."""
-        LOGGER.info("Test mode switch added to Home Assistant, fetching initial status")
-        await super().async_added_to_hass()
-        await self._refresh_test_mode_status()
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable test mode and clear the user-enabled flag."""
+        await super().async_turn_off(**kwargs)
+        if not self._is_on:
+            self._user_enabled = False
 
-    async def _refresh_test_mode_status(self) -> None:
-        """Refresh test mode status from Abode."""
-        try:
-            self._is_on = await self._data.get_test_mode()
-            LOGGER.info("Initial test mode status fetched: %s", self._is_on)
-            self.async_write_ha_state()
-
-            # Enable polling after first successful fetch
-            if not self._initial_sync_done:
-                LOGGER.debug("Enabling polling after initial sync")
-                self._attr_should_poll = True
-                self._initial_sync_done = True
-        except AbodeException as ex:
-            if not self._data.test_mode_supported:
-                LOGGER.info("Test mode unsupported; disabling test mode switch")
-                self._attr_available = False
-                self._attr_should_poll = False
-                self.async_write_ha_state()
-                return
-            LOGGER.error("Failed to get test mode status (AbodeException): %s", ex)
-            import traceback
-
-            LOGGER.debug("Traceback: %s", traceback.format_exc())
-        except Exception as ex:
-            LOGGER.error("Unexpected error getting test mode status: %s", ex)
-            import traceback
-
-            LOGGER.debug("Traceback: %s", traceback.format_exc())
-
-    async def async_update(self) -> None:
-        """Update test mode status."""
-        # Skip polling for 5 seconds after a state change to let API catch up
-        if self._last_state_change is not None:
-            time_since_change = datetime.now(UTC) - self._last_state_change
-            if time_since_change < timedelta(seconds=5):
-                LOGGER.debug("Skipping test mode poll (waiting for API to catch up)")
-                return
-
-        try:
-            previous_state = self._is_on
-            self._is_on = await self._data.get_test_mode()
-
-            LOGGER.debug(
-                "Polling test mode status: was %s, now %s", previous_state, self._is_on
-            )
-
-            if previous_state != self._is_on:
-                LOGGER.info(
-                    "Test mode status changed: %s -> %s", previous_state, self._is_on
-                )
-
-            # If test mode was enabled by user but is now off externally (e.g., 30-min timeout),
-            # stop polling to save resources
-            if self._user_enabled and previous_state and not self._is_on:
-                LOGGER.info(
-                    "Test mode auto-disabled (30-min timeout), stopping polling"
-                )
-                self._user_enabled = False
-                self._attr_should_poll = False
-        except AbodeException as ex:
-            if not self._data.test_mode_supported:
-                LOGGER.info("Test mode unsupported; disabling test mode switch")
-                self._attr_available = False
-                self._attr_should_poll = False
-                self.async_write_ha_state()
-                return
-            LOGGER.error("Failed to update test mode status: %s", ex)
-        except Exception as ex:
-            LOGGER.error("Unexpected error updating test mode status: %s", ex)
-
-    @handle_abode_errors("enable test mode")
-    async def async_turn_on(self, **_kwargs: Any) -> None:
-        """Enable test mode."""
-        await self._data.set_test_mode(True)
-        LOGGER.info("Test mode enabled")
-        self._user_enabled = True  # User explicitly enabled test mode
-        # Trust the state we just set (API may need time to process)
-        self._is_on = True
-        self._last_state_change = datetime.now(UTC)
-        self.schedule_update_ha_state()
-
-    @handle_abode_errors("disable test mode")
-    async def async_turn_off(self, **_kwargs: Any) -> None:
-        """Disable test mode."""
-        await self._data.set_test_mode(False)
-        LOGGER.info("Test mode disabled")
-        self._user_enabled = False  # User explicitly disabled test mode
-        # Trust the state we just set (API may need time to process)
-        self._is_on = False
-        self._last_state_change = datetime.now(UTC)
-        self.schedule_update_ha_state()
-
-    @property
-    def is_on(self) -> bool:
-        """Return True if test mode is enabled."""
-        return self._is_on
+    def _post_update(self, previous: bool, current: bool) -> None:
+        """Stop polling after the API auto-disables a user-enabled test mode."""
+        if self._user_enabled and previous and not current:
+            LOGGER.info("Test mode auto-disabled (30-min timeout), stopping polling")
+            self._user_enabled = False
+            self._attr_should_poll = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,6 +287,18 @@ def pytest_collection_modifyitems(config, items):
         "test_two_concurrent_recreates_run_one_login_at_a_time",
         "test_failure_counter_reset_after_recreate",
         "test_hung_request_finally_skipped_after_generation_bump",
+        # Switch unique_id regression guards (issue #7)
+        "test_test_mode_switch_unique_id_preserved",
+        "test_monitoring_active_switch_unique_id_preserved",
+        "test_send_media_switch_unique_id_preserved",
+        "test_dispatch_without_verification_switch_unique_id_preserved",
+        "test_dispatch_police_switch_unique_id_preserved",
+        "test_dispatch_fire_switch_unique_id_preserved",
+        "test_dispatch_medical_switch_unique_id_preserved",
+        "test_test_mode_switch_name_and_icon",
+        "test_test_mode_switch_uses_test_mode_supported_flag",
+        "test_cms_setting_base_default_support_flag",
+        "test_cms_switches_table_covers_all_legacy_entities",
     }
     # Skip tests with hass fixture except enabled tests
     for item in items:

--- a/tests/test_switch_unique_ids.py
+++ b/tests/test_switch_unique_ids.py
@@ -1,0 +1,133 @@
+"""Pure-unit guards on switch entity unique_ids.
+
+These guard the refactor in #7: collapsing the seven CMS-setting subclasses
+into a table and folding ``AbodeTestModeSwitch`` onto the same base must not
+change any entity's ``unique_id`` (HA's entity_registry would re-register the
+entities under fresh ids and silently break user automations).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from custom_components.abode_security.switch import (
+    _CMS_SWITCHES,
+    AbodeCMSSettingSwitch,
+    AbodeTestModeSwitch,
+)
+
+from .test_constants import (
+    DISPATCH_FIRE_UID,
+    DISPATCH_MEDICAL_UID,
+    DISPATCH_POLICE_UID,
+    DISPATCH_WITHOUT_VERIFICATION_UID,
+    MONITORING_ACTIVE_UID,
+    SEND_MEDIA_UID,
+    TEST_MODE_UID,
+)
+
+CMS_UID_BY_GETTER = {
+    "get_monitoring_active": MONITORING_ACTIVE_UID,
+    "get_send_media": SEND_MEDIA_UID,
+    "get_dispatch_without_verification": DISPATCH_WITHOUT_VERIFICATION_UID,
+    "get_dispatch_police": DISPATCH_POLICE_UID,
+    "get_dispatch_fire": DISPATCH_FIRE_UID,
+    "get_dispatch_medical": DISPATCH_MEDICAL_UID,
+}
+
+
+def _build_alarm() -> Mock:
+    alarm = Mock()
+    alarm.id = "area_1"
+    alarm.name = "Abode Alarm"
+    alarm.type = "Alarm"
+    return alarm
+
+
+def _build_data() -> Mock:
+    return Mock()
+
+
+def test_test_mode_switch_unique_id_preserved() -> None:
+    switch = AbodeTestModeSwitch(_build_data(), _build_alarm())
+    assert switch.unique_id == TEST_MODE_UID
+
+
+def test_monitoring_active_switch_unique_id_preserved() -> None:
+    _assert_cms_unique_id("get_monitoring_active")
+
+
+def test_send_media_switch_unique_id_preserved() -> None:
+    _assert_cms_unique_id("get_send_media")
+
+
+def test_dispatch_without_verification_switch_unique_id_preserved() -> None:
+    _assert_cms_unique_id("get_dispatch_without_verification")
+
+
+def test_dispatch_police_switch_unique_id_preserved() -> None:
+    _assert_cms_unique_id("get_dispatch_police")
+
+
+def test_dispatch_fire_switch_unique_id_preserved() -> None:
+    _assert_cms_unique_id("get_dispatch_fire")
+
+
+def test_dispatch_medical_switch_unique_id_preserved() -> None:
+    _assert_cms_unique_id("get_dispatch_medical")
+
+
+def test_test_mode_switch_name_and_icon() -> None:
+    """Test mode switch keeps its display name + icon after the refactor."""
+    switch = AbodeTestModeSwitch(_build_data(), _build_alarm())
+    assert switch.name == "Test Mode"
+    assert switch.icon == "mdi:test-tube"
+
+
+def test_test_mode_switch_uses_test_mode_supported_flag() -> None:
+    """Test mode switch consults ``test_mode_supported``, not the CMS flag.
+
+    The two attributes are independent on AbodeSystem; mixing them up would
+    silently disable the test-mode switch when CMS is unsupported (or vice
+    versa).
+    """
+    switch = AbodeTestModeSwitch(_build_data(), _build_alarm())
+    assert switch._support_flag == "test_mode_supported"
+
+
+def test_cms_setting_base_default_support_flag() -> None:
+    base = AbodeCMSSettingSwitch(
+        _build_data(),
+        _build_alarm(),
+        name="Monitoring Active",
+        icon="mdi:shield-check",
+        getter_name="get_monitoring_active",
+        setter_name="set_monitoring_active",
+    )
+    assert base._support_flag == "cms_settings_supported"
+
+
+def test_cms_switches_table_covers_all_legacy_entities() -> None:
+    """The table must cover every CMS-setting switch the integration shipped."""
+    table_getters = {row[2] for row in _CMS_SWITCHES}
+    assert table_getters == set(CMS_UID_BY_GETTER)
+
+
+def _assert_cms_unique_id(getter_name: str) -> None:
+    name, icon, getter, setter = _row_for(getter_name)
+    switch = AbodeCMSSettingSwitch(
+        _build_data(),
+        _build_alarm(),
+        name=name,
+        icon=icon,
+        getter_name=getter,
+        setter_name=setter,
+    )
+    assert switch.unique_id == CMS_UID_BY_GETTER[getter_name]
+
+
+def _row_for(getter_name: str) -> tuple[str, str, str, str]:
+    for row in _CMS_SWITCHES:
+        if row[2] == getter_name:
+            return row
+    raise AssertionError(f"No _CMS_SWITCHES row for {getter_name!r}")


### PR DESCRIPTION
## Summary

- `AbodeTestModeSwitch` now inherits from `AbodeCMSSettingSwitch` — the bespoke 137-line class collapses to ~30 lines that override only the user-enabled tracking and the auto-stop-polling hook.
- The six boilerplate CMS-setting subclasses (`AbodeMonitoringActiveSwitch`, `AbodeSendMediaSwitch`, the four `Dispatch*` switches) collapse into a `_CMS_SWITCHES` tuple table iterated in `async_setup_entry`.
- `switch.py` shrinks from 823 → 686 lines (−137 net).

## Root cause

`switch.py` accumulated seven near-identical CMS-setting subclasses plus an `AbodeTestModeSwitch` that duplicated nearly all of `AbodeCMSSettingSwitch`. The base class needed three small extension points to host both shapes:
- `unique_id_suffix` (preserves `area_1-test-mode` while keeping the existing getter-derived form for the CMS settings).
- `support_flag` (test mode reads `test_mode_supported`; CMS reads `cms_settings_supported`).
- `_post_update(previous, current)` hook (default no-op; test mode uses it for the 30-min server-side auto-disable handling).

## Behavior preservation

- **Unique IDs:** every entity keeps its existing identifier (`area_1-test-mode`, `area_1-get-monitoring-active`, …, `area_1-get-dispatch-medical`). Changing these would silently break user automations. The new `tests/test_switch_unique_ids.py` pins them as a regression guard.
- **`_user_enabled` semantics:** the subclass overrides `async_turn_on/off` to set `_user_enabled` *after* `super()` and only when `self._is_on` flipped — preserving the original "on `AbodeError`, the flag stays put" behavior (since `@handle_abode_errors` short-circuits the parent body before `_is_on` is mutated).

## Side effect (intentional upgrade)

Test mode now inherits the connection-aware polling skip, the 3-strikes error counter, and mark-available-on-recovery handling that the CMS-setting switches already had. Strictly an improvement — the CMS resilience model now applies to test mode too.

## Test plan

- [x] Added `tests/test_switch_unique_ids.py` — pure-unit regression guards on the seven `unique_id`s plus support-flag wiring and table coverage. 11 tests, all run in CI.
- [x] Verified existing CMS/test-mode integration tests are unchanged (they exercise the same code paths through the now-shared base class).
- [x] `ruff check`, `ruff format --check`, `mypy`, and the unit suite (145 passed) pass cleanly.
- [x] Pre-commit review: APPROVED.

Fixes #7
