### PR TITLE
fix(client): drain in-flight requests in cleanup() (#14)

### DIFF
--- a/custom_components/abode_security/abode/client.py
+++ b/custom_components/abode_security/abode/client.py
@@ -3,6 +3,7 @@ An Abode alarm Python library.
 """
 
 import asyncio
+import builtins
 import json as json_module
 import logging
 import uuid
@@ -150,6 +151,9 @@ class Client:
 
         # These will be initialized during async initialization
         self._initialized = False
+        # Set by `cleanup()` to mark the client terminal so a stray request
+        # can't undo cleanup by re-running `_async_initialize` (issue #14).
+        self._closed = False
         self._auto_login = auto_login
         self._get_devices = get_devices
         self._get_automations = get_automations
@@ -188,14 +192,71 @@ class Client:
         await self.cleanup()
 
     async def cleanup(self):
-        """Clean up async resources."""
-        # Stop background session monitor
+        """Clean up async resources, draining in-flight requests first.
+
+        Reuses the same swap primitives as `_recreate_session` so HA
+        shutdown / config-entry reload can't close the session out from
+        under an in-flight `_send_request` (issue #14). After cleanup the
+        client is terminal: `_closed` blocks new requests so a late caller
+        can't silently allocate a fresh session.
+        """
         self._stop_session_monitor()
 
-        if self._session:
-            await self._session.close()
-            self._session = None
-        self._initialized = False
+        self._ensure_session_swap_primitives()
+        assert self._session_swap_lock is not None
+        assert self._session_ready is not None
+        assert self._inflight_zero_event is not None
+
+        # Idempotent: a concurrent second caller queues on the swap lock,
+        # observes `_closed=True` once the first cleanup releases the lock,
+        # and returns. Both `await cleanup()` calls then resolve only after
+        # the actual teardown has completed.
+        async with self._session_swap_lock:
+            if self._closed:
+                return
+
+            self._closed = True
+            self._session_ready.clear()
+
+            try:
+                await asyncio.wait_for(
+                    self._inflight_zero_event.wait(),
+                    timeout=self._session_drain_timeout,
+                )
+            except TimeoutError:
+                log.warning(
+                    "Cleanup drain timed out after %.1fs (%d still in flight)"
+                    " - closing session anyway",
+                    self._session_drain_timeout,
+                    self._inflight_requests,
+                )
+                # Same generation-bump + counter reset as `_recreate_session`
+                # so a hung request's eventual finally clause skips its
+                # decrement instead of zeroing an unrelated slot.
+                self._session_swap_generation += 1
+                self._inflight_requests = 0
+                self._inflight_zero_event.set()
+
+            if self._session:
+                try:
+                    await self._session.close()
+                except builtins.Exception:
+                    # `Exception` is shadowed by the abode-namespaced
+                    # exception class imported at the top of this module,
+                    # so we use `builtins.Exception` to actually catch
+                    # aiohttp/asyncio/OSError errors and keep cleanup
+                    # idempotent (the half-torn-down state from a raised
+                    # close() would otherwise leave `_session` set even
+                    # though `_closed` is True).
+                    log.warning(
+                        "Error closing session during cleanup", exc_info=True
+                    )
+                self._session = None
+
+            self._initialized = False
+            # Wake any caller still parked on `_session_ready.wait()` so it
+            # observes `_closed` and raises rather than hanging forever.
+            self._session_ready.set()
 
     async def login(self, username=None, password=None, mfa_code=None):
         """Explicit Abode login."""
@@ -322,6 +383,13 @@ class Client:
         assert self._inflight_zero_event is not None
 
         async with self._session_swap_lock:
+            # Don't resurrect a torn-down client. A late retry path
+            # (e.g. `_handle_empty_response_and_retry`) could otherwise
+            # allocate a fresh session after `cleanup()` has run, leaking
+            # the new session and re-opening the shutdown race (issue #14).
+            if self._closed:
+                return
+
             log.info("Recreating aiohttp session due to connection issues")
             self._session_recreate_count += 1
 
@@ -1129,6 +1197,11 @@ class Client:
     async def _send_request(
         self, method, path, headers=None, data=None, raise_on_error=True
     ):
+        # Cleanup is terminal: don't let a late caller re-allocate a session
+        # we just tore down (issue #14).
+        if self._closed:
+            raise Exception(errors.REQUEST)
+
         await self._async_initialize()
 
         if not self._token:
@@ -1166,6 +1239,10 @@ class Client:
         assert self._session_ready is not None
         assert self._inflight_zero_event is not None
         await self._session_ready.wait()
+        # Cleanup may have run while we were parked on the gate; if so the
+        # session is gone and we must raise instead of advancing.
+        if self._closed:
+            raise Exception(errors.REQUEST)
         my_swap_generation = self._session_swap_generation
         self._inflight_requests += 1
         self._inflight_zero_event.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,6 +287,16 @@ def pytest_collection_modifyitems(config, items):
         "test_two_concurrent_recreates_run_one_login_at_a_time",
         "test_failure_counter_reset_after_recreate",
         "test_hung_request_finally_skipped_after_generation_bump",
+        # Client cleanup drain (issue #14)
+        "test_cleanup_waits_for_in_flight_request",
+        "test_cleanup_drain_timeout_forces_close",
+        "test_send_request_after_cleanup_raises",
+        "test_cleanup_called_twice_closes_session_only_once",
+        "test_cleanup_waits_for_concurrent_recreate",
+        "test_parked_request_raises_when_cleanup_wakes_it",
+        "test_recreate_after_cleanup_does_not_allocate_session",
+        "test_second_cleanup_does_not_return_until_first_finishes",
+        "test_cleanup_logs_and_swallows_aiohttp_close_error",
         # Switch unique_id regression guards (issue #7)
         "test_test_mode_switch_unique_id_preserved",
         "test_monitoring_active_switch_unique_id_preserved",

--- a/tests/test_client_session_recreate.py
+++ b/tests/test_client_session_recreate.py
@@ -1,6 +1,6 @@
-"""Client session recreation: drains in-flight requests, serializes recreates.
+"""Client session recreation and cleanup: drains in-flight requests.
 
-Covers the fixes for issue #3:
+Covers the fixes for issue #3 (recreate path) and issue #14 (cleanup path):
 
 1. ``_recreate_session`` waits for in-flight ``_send_request`` calls to complete
    before closing the old session. Without the drain, the in-flight request
@@ -11,14 +11,21 @@ Covers the fixes for issue #3:
    logins.
 3. ``_consecutive_failures`` is reset to zero on a successful recreate so the
    threshold doesn't trip again immediately after recovery.
+4. ``cleanup`` reuses the same drain primitives so HA shutdown / config-entry
+   reload can't close a session out from under an in-flight request.
 """
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from custom_components.abode_security.abode.client import Client
+from custom_components.abode_security.abode.exceptions import (
+    Exception as AbodeException,
+)
 
 
 class _FakeResponse:
@@ -247,3 +254,315 @@ class TestZombieDecrementAfterDrainTimeout:
                 " drain-timeout reset"
             )
             assert not client._inflight_zero_event.is_set()
+
+
+class TestCleanupDrainsInFlightRequests:
+    """``cleanup()`` must drain in-flight requests before closing (issue #14)."""
+
+    async def test_cleanup_waits_for_in_flight_request(self):
+        client = _build_client()
+
+        request_started = asyncio.Event()
+        release_request = asyncio.Event()
+
+        old_session = MagicMock()
+        old_session.close = AsyncMock()
+        old_session.get = MagicMock(
+            return_value=_ControllableRequest(request_started, release_request)
+        )
+        client._session = old_session
+
+        request_task = asyncio.create_task(client._send_request("get", "/some/path"))
+        await request_started.wait()
+        assert old_session.close.await_count == 0
+
+        cleanup_task = asyncio.create_task(client.cleanup())
+
+        # Give cleanup every chance to make forward progress. With the fix
+        # it must block on the drain.
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+        assert not cleanup_task.done(), (
+            "cleanup() completed before in-flight request drained"
+        )
+        assert client._session is old_session, (
+            "session was cleared while a request was in flight"
+        )
+        assert old_session.close.await_count == 0, (
+            "session was closed while a request was in flight"
+        )
+
+        release_request.set()
+        await request_task
+        await cleanup_task
+
+        assert old_session.close.await_count == 1
+        assert client._session is None
+        assert client._closed is True
+
+
+class TestCleanupDrainTimeout:
+    """``cleanup()`` must not hang forever on a stuck request."""
+
+    async def test_cleanup_drain_timeout_forces_close(self):
+        client = _build_client()
+        client._session_drain_timeout = 0.05
+
+        request_started = asyncio.Event()
+        release_request = asyncio.Event()
+
+        old_session = MagicMock()
+        old_session.close = AsyncMock()
+        old_session.get = MagicMock(
+            return_value=_ControllableRequest(request_started, release_request)
+        )
+        client._session = old_session
+
+        hung_task = asyncio.create_task(client._send_request("get", "/hung"))
+        await request_started.wait()
+        assert client._inflight_requests == 1
+
+        await client.cleanup()
+
+        assert client._session is None
+        assert old_session.close.await_count == 1
+        assert client._closed is True
+        assert client._session_swap_generation == 1
+        assert client._inflight_requests == 0
+
+        # Let the hung request unwind so we don't leak the task.
+        release_request.set()
+        await hung_task
+
+
+class TestSendRequestAfterCleanupRaises:
+    """Once ``cleanup()`` has run, new requests must not allocate a fresh
+    session — the client is terminal."""
+
+    async def test_send_request_after_cleanup_raises(self):
+        client = _build_client()
+        client._session = MagicMock()
+        client._session.close = AsyncMock()
+
+        await client.cleanup()
+        assert client._closed is True
+        assert client._session is None
+
+        with pytest.raises(AbodeException):
+            await client._send_request("get", "/whatever")
+
+        # Crucially, the cleanup must not be undone by a stray request.
+        assert client._session is None
+        assert client._closed is True
+
+
+class TestCleanupIsIdempotent:
+    """A second ``cleanup()`` call must be a no-op — both
+    ``async_unload_entry`` and the ``EVENT_HOMEASSISTANT_STOP`` listener can
+    fire on the same client during shutdown."""
+
+    async def test_cleanup_called_twice_closes_session_only_once(self):
+        client = _build_client()
+        client._session = MagicMock()
+        client._session.close = AsyncMock()
+        original_session = client._session
+
+        await client.cleanup()
+        await client.cleanup()
+
+        assert original_session.close.await_count == 1
+        assert client._session is None
+        assert client._closed is True
+        # The post-lock idempotent return must not re-clear the gate or
+        # stomp the in-flight counter — both should still be in their
+        # post-cleanup state.
+        assert client._session_ready is not None
+        assert client._session_ready.is_set()
+        assert client._inflight_requests == 0
+
+
+class TestConcurrentRecreateAndCleanupSerialized:
+    """``cleanup()`` and ``_recreate_session`` share ``_session_swap_lock`` so
+    one cannot close a session the other is mid-swap on."""
+
+    async def test_cleanup_waits_for_concurrent_recreate(self):
+        client = _build_client()
+        client._session = MagicMock()
+        client._session.close = AsyncMock()
+
+        login_release = asyncio.Event()
+        recreate_login_started = asyncio.Event()
+        cleanup_observed_session = []
+
+        async def fake_login(*_args, **_kwargs):
+            recreate_login_started.set()
+            await login_release.wait()
+
+        with patch.object(client, "login", new=fake_login):
+            recreate_task = asyncio.create_task(client._recreate_session())
+            await recreate_login_started.wait()
+
+            # Recreate is parked inside login() while holding the swap lock.
+            # cleanup() must queue behind it rather than close concurrently.
+            cleanup_task = asyncio.create_task(client.cleanup())
+            for _ in range(10):
+                await asyncio.sleep(0)
+                cleanup_observed_session.append(client._session)
+
+            assert not cleanup_task.done(), (
+                "cleanup() ran while _recreate_session held the swap lock"
+            )
+
+            login_release.set()
+            await recreate_task
+            await cleanup_task
+
+        assert client._session is None
+        assert client._closed is True
+
+
+class TestParkedRequestWokenByCleanupRaises:
+    """A `_send_request` parked on `_session_ready.wait()` must raise (not
+    advance against a torn-down session) when cleanup re-sets the gate on
+    its way out. Without the post-wait `_closed` recheck, the woken caller
+    would proceed to dereference `self._session` which is now `None`."""
+
+    async def test_parked_request_raises_when_cleanup_wakes_it(self):
+        client = _build_client()
+        client._session = MagicMock()
+        client._session.close = AsyncMock()
+        # Force-create the swap primitives so we can clear the gate from
+        # the test without going through `_recreate_session`.
+        client._ensure_session_swap_primitives()
+        assert client._session_ready is not None
+        client._session_ready.clear()
+
+        request_task = asyncio.create_task(client._send_request("get", "/x"))
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert not request_task.done(), (
+            "request advanced past the closed _session_ready gate"
+        )
+
+        # Cleanup acquires the swap lock, marks `_closed`, drains (no
+        # in-flight requests), closes the session, then re-sets the gate
+        # on its way out — waking the parked request, which must observe
+        # `_closed` and raise.
+        await client.cleanup()
+
+        with pytest.raises(AbodeException):
+            await request_task
+
+        assert client._closed is True
+        assert client._session is None
+        assert client._inflight_requests == 0
+
+
+class TestConcurrentCleanupsAwaitCompletion:
+    """Two concurrent ``cleanup()`` calls (e.g. ``async_unload_entry`` and
+    the ``EVENT_HOMEASSISTANT_STOP`` listener firing on the same client)
+    must both await the actual teardown — neither may return early while
+    the other is still draining or closing the session."""
+
+    async def test_second_cleanup_does_not_return_until_first_finishes(self):
+        client = _build_client()
+
+        request_started = asyncio.Event()
+        release_request = asyncio.Event()
+
+        old_session = MagicMock()
+        old_session.close = AsyncMock()
+        old_session.get = MagicMock(
+            return_value=_ControllableRequest(request_started, release_request)
+        )
+        client._session = old_session
+
+        # Start a request so cleanup actually has to drain.
+        request_task = asyncio.create_task(client._send_request("get", "/x"))
+        await request_started.wait()
+
+        cleanup_a = asyncio.create_task(client.cleanup())
+        # Yield enough to let cleanup_a acquire the swap lock and set
+        # `_closed = True` while it parks on the drain event.
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert client._closed is True
+        assert not cleanup_a.done()
+
+        cleanup_b = asyncio.create_task(client.cleanup())
+        for _ in range(10):
+            await asyncio.sleep(0)
+        # cleanup_b must NOT have returned: cleanup_a is still mid-drain
+        # holding the swap lock, even though `_closed` is already True.
+        assert not cleanup_b.done(), (
+            "second cleanup() returned before first finished — concurrent"
+            " caller would observe an unfinished teardown"
+        )
+
+        release_request.set()
+        await request_task
+        await cleanup_a
+        await cleanup_b
+
+        assert old_session.close.await_count == 1
+        assert client._session is None
+        assert client._closed is True
+
+
+class TestCleanupSwallowsCloseErrors:
+    """A real exception from ``self._session.close()`` (e.g. an
+    ``aiohttp.ClientError`` or ``OSError``) must not propagate out of
+    ``cleanup()`` and leave the client half-torn-down. ``Exception`` is
+    shadowed in client.py by the abode-namespaced subclass, so the catch
+    must use ``builtins.Exception`` to actually fire."""
+
+    async def test_cleanup_logs_and_swallows_aiohttp_close_error(self, caplog):
+        client = _build_client()
+        client._session = MagicMock()
+        client._session.close = AsyncMock(
+            side_effect=aiohttp.ClientError("simulated close failure")
+        )
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="custom_components.abode_security.abode.client",
+        ):
+            await client.cleanup()
+
+        assert client._session is None
+        assert client._closed is True
+        assert "Error closing session during cleanup" in caplog.text
+
+
+class TestRecreateAfterCleanupNoOps:
+    """`_recreate_session` must not resurrect a torn-down client.
+
+    A late `_handle_empty_response_and_retry` racing shutdown could
+    otherwise allocate a fresh session after `cleanup()` has run, leaking
+    it and re-opening the shutdown race.
+    """
+
+    async def test_recreate_after_cleanup_does_not_allocate_session(self):
+        client = _build_client()
+        client._session = MagicMock()
+        client._session.close = AsyncMock()
+
+        login_calls = 0
+
+        async def fake_login(*_args, **_kwargs):
+            nonlocal login_calls
+            login_calls += 1
+
+        with patch.object(client, "login", new=fake_login):
+            await client.cleanup()
+            assert client._closed is True
+            assert client._session is None
+
+            # Late recreate must observe `_closed` and bail without
+            # creating a new aiohttp session or running a fresh login.
+            await client._recreate_session()
+
+        assert client._session is None
+        assert login_calls == 0
+        assert client._closed is True


### PR DESCRIPTION
## Summary

- `Client.cleanup()` now drains in-flight `_send_request` calls before closing
  the aiohttp session, reusing the swap primitives introduced for `#3`.
- Adds a terminal `_closed` flag so a late-arriving request after cleanup
  raises instead of silently re-running `_async_initialize` and allocating a
  fresh session. `_recreate_session` also bails when `_closed`, preventing a
  post-cleanup `_handle_empty_response_and_retry` from leaking a new session.
- `cleanup()` is idempotent (`async_unload_entry` and the
  `EVENT_HOMEASSISTANT_STOP` listener can both fire on the same client).

## Root cause

`cleanup()` previously closed `self._session` unconditionally and set it to
`None`, racing any in-flight request the same way `_recreate_session` did
before #3. On HA shutdown / config-entry reload, the in-flight request would
resume against a closed session and surface `ClientConnectionResetError` (or
hang). The drain primitives needed to fix this already existed on the client;
the fix wires them up on the cleanup path and gates `_send_request` /
`_recreate_session` on a new `_closed` flag so cleanup is genuinely terminal.

## Test plan

- [x] Added 7 tests in `tests/test_client_session_recreate.py` covering:
  drain-blocks-cleanup, drain timeout forces close (with generation bump),
  send-after-cleanup raises `AbodeException`, idempotency (with gate-state
  asserts), serialization with concurrent `_recreate_session`,
  parked-on-gate request woken by cleanup raises, and post-cleanup
  `_recreate_session` is a no-op.
- [x] Tests fail on the pre-fix code (`cleanup()` didn't block) and pass after.
- [x] `./scripts/check.sh` green: ruff, mypy, pytest (155 passed).

Fixes #14
