### PR TITLE
test(client): stub aiohttp.TCPConnector in session-recreate tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,6 +297,8 @@ def pytest_collection_modifyitems(config, items):
         "test_recreate_after_cleanup_does_not_allocate_session",
         "test_second_cleanup_does_not_return_until_first_finishes",
         "test_cleanup_logs_and_swallows_aiohttp_close_error",
+        # Test fixture hygiene — TCPConnector stub (issue #15)
+        "test_recreate_session_does_not_construct_real_connector",
         # Switch unique_id regression guards (issue #7)
         "test_test_mode_switch_unique_id_preserved",
         "test_monitoring_active_switch_unique_id_preserved",

--- a/tests/test_client_session_recreate.py
+++ b/tests/test_client_session_recreate.py
@@ -74,9 +74,12 @@ def _stub_sync_socketio_cookies(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _stub_aiohttp_client_session(monkeypatch):
-    """Replace the aiohttp.ClientSession constructor used inside
-    _recreate_session so tests don't allocate (and leak) a real session."""
+def _stub_aiohttp_session_and_connector(monkeypatch):
+    """Replace the aiohttp.ClientSession and TCPConnector constructors used
+    inside _recreate_session so tests don't allocate (and leak) a real
+    session or connector. A real TCPConnector registers with the running
+    loop and emits an "Unclosed connector" ResourceWarning at GC under
+    stricter warning configurations (e.g. PYTHONDEVMODE=1)."""
     fake_session_factory = MagicMock(
         side_effect=lambda *_a, **_kw: MagicMock(close=AsyncMock())
     )
@@ -84,6 +87,39 @@ def _stub_aiohttp_client_session(monkeypatch):
         "custom_components.abode_security.abode.client.aiohttp.ClientSession",
         fake_session_factory,
     )
+    monkeypatch.setattr(
+        "custom_components.abode_security.abode.client.aiohttp.TCPConnector",
+        MagicMock(side_effect=lambda *_a, **_kw: MagicMock()),
+    )
+
+
+class TestRecreateSessionStubsTCPConnector:
+    """The autouse fixture must stub ``aiohttp.TCPConnector`` alongside
+    ``aiohttp.ClientSession`` so ``_recreate_session`` doesn't allocate a
+    real connector that registers with the running loop and emits an
+    "Unclosed connector" ResourceWarning at GC under stricter warning
+    configurations (e.g. ``PYTHONDEVMODE=1``)."""
+
+    async def test_recreate_session_does_not_construct_real_connector(self):
+        client = _build_client()
+        client._session = MagicMock()
+        client._session.close = AsyncMock()
+
+        with patch.object(client, "login", new=AsyncMock()):
+            await client._recreate_session()
+
+        from custom_components.abode_security.abode.client import (
+            aiohttp as client_aiohttp,
+        )
+
+        assert isinstance(client_aiohttp.TCPConnector, MagicMock), (
+            "aiohttp.TCPConnector must be patched in this test module so "
+            "_recreate_session doesn't leak a real connector at GC"
+        )
+        assert client_aiohttp.TCPConnector.call_count >= 1, (
+            "expected _recreate_session to construct (the patched) "
+            "TCPConnector at least once per recreate"
+        )
 
 
 class TestSessionRecreateDrainsInFlightRequests:


### PR DESCRIPTION
## Summary

- Extends the autouse fixture in `tests/test_client_session_recreate.py` to also stub `aiohttp.TCPConnector`, matching the existing `aiohttp.ClientSession` stub.
- Adds a regression test (`TestRecreateSessionStubsTCPConnector`) that calls `_recreate_session()` and asserts the patched constructor is in place and was invoked.
- Pure test hygiene; no production behavior change.

## Root cause

The fixture stubbed `aiohttp.ClientSession` but not `aiohttp.TCPConnector`. Each call to `_recreate_session()` (`custom_components/abode_security/abode/client.py:427`) constructed a real `TCPConnector(limit=10, limit_per_host=5)` that registered with the running loop. Without a `connector.close()`, aiohttp emits an "Unclosed connector" warning at GC. Tests pass today because `ResourceWarning` only fires at GC and the default warning filter, but `PYTHONDEVMODE=1` or `-W error::ResourceWarning` would surface it.

## Test plan

- [x] Added test that fails before the fix (real `TCPConnector` class, not a `MagicMock`)
- [x] Verified test passes after the fix
- [x] Full `./scripts/check.sh` suite passes (lint + mypy + pytest)
- [x] New test added to `tests/conftest.py::enabled_tests` allowlist (per `CLAUDE.md` testing-gotchas note)

Fixes #15
