### PR TITLE
ci(frontend): wire typecheck + tests into CI and pre-commit (#30 MVP)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -26,4 +26,10 @@ python3 -m mypy custom_components/abode_security --ignore-missing-imports
 echo "Running tests with pytest..."
 python3 -m pytest tests/ -v --tb=short
 
+# Frontend gates — only run when frontend files are staged
+if git diff --name-only --cached | grep -q '^frontend/'; then
+    echo "Frontend changes detected — running frontend gates..."
+    (cd frontend && npm run typecheck && npm test)
+fi
+
 echo "Pre-commit checks passed!"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,6 +59,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run tests
+        run: npm test
+
       - name: Build frontend
         run: npm run build
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
+        "@types/mocha": "^10.0.10",
         "@types/sinon": "^21.0.0",
         "@web/dev-server-esbuild": "^1.0.4",
         "@web/test-runner": "^0.18.0",
@@ -1409,6 +1410,13 @@
         "@types/koa": "*"
       }
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.0.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
@@ -2723,8 +2731,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -4816,7 +4823,6 @@
       "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5401,8 +5407,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -5457,7 +5462,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "watch": "rollup -c -w",
     "dev": "rollup -c -w --environment BUILD:development",
     "test": "web-test-runner --node-resolve",
-    "test:watch": "web-test-runner --node-resolve --watch"
+    "test:watch": "web-test-runner --node-resolve --watch",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "home-assistant",
@@ -26,6 +27,7 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
+    "@types/mocha": "^10.0.10",
     "@types/sinon": "^21.0.0",
     "@web/dev-server-esbuild": "^1.0.4",
     "@web/test-runner": "^0.18.0",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "experimentalDecorators": true,

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -37,6 +37,15 @@ echo ""
 echo "Running unit tests with pytest..."
 uv run pytest tests/ -v --tb=short
 
+# Frontend gates (typecheck + tests) — only when this branch (or working tree)
+# differs from origin/main on frontend files. Mirrors the pre-commit hook's
+# selectivity so backend-only iterations don't pay the Playwright cost.
+if git diff --name-only origin/main 2>/dev/null | grep -q '^frontend/'; then
+    echo ""
+    echo "Frontend changes detected — running frontend gates..."
+    (cd frontend && npm run typecheck && npm test)
+fi
+
 echo ""
 echo -e "${GREEN}=========================================${NC}"
 echo -e "${GREEN}All checks passed!${NC}"


### PR DESCRIPTION
## Summary

PR1 of a multi-PR sweep addressing the open frontend issues. This is the **MVP scope** of #30: wire `tsc --noEmit` and `npm test` into CI and the pre-commit hook so subsequent frontend PRs land with a safety net. The full ESLint + Prettier + tsconfig-strictness stack is deferred to a follow-up PR (also part of #30) so this PR doesn't balloon into fixing every latent lint issue.

- `frontend/package.json` — add `typecheck` script (`tsc --noEmit`); add `@types/mocha` so test files type-check against the Mocha BDD globals exposed by `web-test-runner`.
- `frontend/tsconfig.json` — `ignoreDeprecations: "5.0"` to silence the deprecated `moduleResolution: "node"` warning. Proper migration to `"bundler"` belongs in the lint-stack follow-up.
- `.github/workflows/tests.yaml` — install Playwright Chromium, then run `npm run typecheck` + `npm test` before the existing build step in the frontend job.
- `.githooks/pre-commit` — run the same pair only when staged files include anything under `frontend/` (avoids slowing down backend-only commits).
- `scripts/check.sh` — mirror the new frontend gates so the script keeps matching the pre-commit hook (per CLAUDE.md).

## Test plan

- [ ] `npm run typecheck` exits 0 on a clean tree, exits non-zero when a deliberate type error is added (verified locally: exit 2).
- [ ] `npm test` passes (verified locally: 31 tests).
- [ ] CI workflow runs the new steps and reports the frontend job green.
- [ ] Pre-commit hook fires the frontend gate when frontend files are staged, skips when only backend files are staged.

## Coordination

This is the first of ~11 PRs. After this merges, PR2 (#23 confirm-dialog refactor) follows on a fresh branch from `main`.

Closes #30 (partial — full lint stack in follow-up).
