### PR TITLE
fix(frontend): drive editor sensor categories from response keys (fixes #25)

### DIFF
--- a/frontend/src/__tests__/action-editor.test.ts
+++ b/frontend/src/__tests__/action-editor.test.ts
@@ -9,6 +9,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 
 import '../action-editor.js';
 import type { ActionEditor } from '../action-editor.js';
+import type { SensorEntity } from '../types.js';
 import {
   createMockHass,
   createMockAction,
@@ -71,6 +72,77 @@ describe('ActionEditor', () => {
       // Should show sensor categories (first letter capitalized)
       expect(el.shadowRoot?.textContent).to.include('Door');
       expect(el.shadowRoot?.textContent).to.include('Motion');
+    });
+
+    it('renders categories returned by the backend even when not in the legacy allowlist', async () => {
+      const hass = createMockHass();
+      const el = await fixture<ActionEditor>(html`
+        <abode-action-editor .hass=${hass}></abode-action-editor>
+      `);
+
+      // Intentionally use device_class keys outside the legacy seven-name
+      // allowlist — this is the shape the HA backend actually returns.
+      const wideSensors: Record<string, SensorEntity[]> = {
+        garage_door: [
+          { entity_id: 'binary_sensor.garage', name: 'Garage Door', state: 'closed' },
+        ],
+        gas: [
+          { entity_id: 'binary_sensor.gas_kitchen', name: 'Kitchen Gas', state: 'off' },
+        ],
+      };
+      // @ts-expect-error - accessing private property for testing
+      el._sensors = wideSensors;
+      // @ts-expect-error - accessing private property for testing
+      el._alarms = createMockAlarms();
+      // @ts-expect-error - accessing private property for testing
+      el._loading = false;
+      await elementUpdated(el);
+
+      // Both non-allowlisted categories should appear as category headers,
+      // and each sensor inside should be selectable. Match case-insensitively
+      // so a future title-case label map can't make this test brittle.
+      const categoryHeaders = Array.from(
+        el.shadowRoot?.querySelectorAll('.category-header span') ?? [],
+      ).map((s) => s.textContent ?? '');
+      expect(categoryHeaders.some((l) => /garage[\s_]door/i.test(l))).to.equal(
+        true,
+        `expected a "garage door" category header, got: ${JSON.stringify(categoryHeaders)}`,
+      );
+      expect(categoryHeaders.some((l) => /\bgas\b/i.test(l))).to.equal(
+        true,
+        `expected a "gas" category header, got: ${JSON.stringify(categoryHeaders)}`,
+      );
+      expect(el.shadowRoot?.textContent).to.include('Garage Door');
+      expect(el.shadowRoot?.textContent).to.include('Kitchen Gas');
+    });
+
+    it('skips categories with zero sensors', async () => {
+      const hass = createMockHass();
+      const el = await fixture<ActionEditor>(html`
+        <abode-action-editor .hass=${hass}></abode-action-editor>
+      `);
+
+      // @ts-expect-error - accessing private property for testing
+      el._sensors = {
+        door: [
+          { entity_id: 'binary_sensor.front', name: 'Front Door', state: 'off' },
+        ],
+        motion: [],
+      };
+      // @ts-expect-error - accessing private property for testing
+      el._alarms = createMockAlarms();
+      // @ts-expect-error - accessing private property for testing
+      el._loading = false;
+      await elementUpdated(el);
+
+      const categoryHeaders = Array.from(
+        el.shadowRoot?.querySelectorAll('.category-header span') ?? [],
+      ).map((s) => s.textContent ?? '');
+      expect(categoryHeaders.some((l) => /\bdoor\b/i.test(l))).to.equal(true);
+      expect(categoryHeaders.some((l) => /\bmotion\b/i.test(l))).to.equal(
+        false,
+        'empty motion category should be skipped',
+      );
     });
 
     it('displays alarm options', async () => {

--- a/frontend/src/action-editor.ts
+++ b/frontend/src/action-editor.ts
@@ -556,23 +556,16 @@ export class ActionEditor extends LitElement {
   }
 
   private _renderSensorSelection() {
-    if (!this._sensors) {
+    const sensorsByCategory = this._sensors;
+    if (!sensorsByCategory) {
       return html`<div class="loading">Loading sensors...</div>`;
     }
 
-    const categories: SensorCategory[] = [
-      'door',
-      'window',
-      'motion',
-      'moisture',
-      'smoke',
-      'connectivity',
-      'other',
-    ];
-
-    const nonEmptyCategories = categories.filter(
-      (cat) => (this._sensors![cat] || []).length > 0
-    );
+    // Drive categories from the response keys, not a frontend allowlist —
+    // the backend keys by HA `device_class`, which is open-ended.
+    const nonEmptyCategories = Object.keys(sensorsByCategory)
+      .filter((cat) => (sensorsByCategory[cat] ?? []).length > 0)
+      .sort();
 
     if (nonEmptyCategories.length === 0) {
       return html`<div class="loading">No sensors available</div>`;
@@ -581,7 +574,7 @@ export class ActionEditor extends LitElement {
     return html`
       <div class="sensor-categories">
         ${nonEmptyCategories.map((category) => {
-          const sensors = this._sensors![category] || [];
+          const sensors = sensorsByCategory[category] ?? [];
           return html`
             <div class="category">
               <div class="category-header" @click=${() => this._toggleCategory(category)}>
@@ -592,7 +585,7 @@ export class ActionEditor extends LitElement {
                   @click=${(e: Event) => e.stopPropagation()}
                   @change=${() => this._toggleCategory(category)}
                 />
-                <span>${category} (${sensors.length})</span>
+                <span>${category.replace(/_/g, ' ')} (${sensors.length})</span>
               </div>
               <div class="category-items">
                 ${sensors.map(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -34,7 +34,13 @@ export interface SensorEntity {
   state: string;
 }
 
-// Backend omits categories with zero sensors, so all keys are optional.
+// Backend keys sensors by Home Assistant `device_class`, which is open-ended
+// (garage_door, gas, heat, vibration, …). Use a string-keyed map so unknown
+// categories surface in the editor instead of being silently dropped.
+export type SensorsByCategory = Partial<Record<string, SensorEntity[]>>;
+
+// Legacy literal union of well-known categories. Kept for callsites that want
+// a typed iterator or label map; not used as the key type of SensorsByCategory.
 export type SensorCategory =
   | 'door'
   | 'window'
@@ -43,8 +49,6 @@ export type SensorCategory =
   | 'smoke'
   | 'connectivity'
   | 'other';
-
-export type SensorsByCategory = Partial<Record<SensorCategory, SensorEntity[]>>;
 
 export interface AlarmEntity {
   entity_id: string;


### PR DESCRIPTION
## Summary

PR3 of the frontend sweep. Fixes #25: the action editor was silently dropping sensors whose Home Assistant `device_class` wasn't in a hardcoded seven-name allowlist (`door`, `window`, `motion`, `moisture`, `smoke`, `connectivity`, `other`). Real binary_sensors with `device_class: garage_door`, `gas`, `vibration`, `tamper`, etc. — common in many HA setups — were invisible in the editor: unselectable for new actions and unrendered for existing actions that already referenced them.

- **`types.ts`** — open `SensorsByCategory` from `Partial<Record<SensorCategory, SensorEntity[]>>` to `Partial<Record<string, SensorEntity[]>>`. The legacy `SensorCategory` literal union stays exported for callsites that want a typed iterator or friendly-label map; PR7 (#33) will reorganize it.
- **`action-editor.ts`** — replace the hardcoded `categories` array with `Object.keys(this._sensors).filter(non-empty).sort()`. Rendered headers `replace(/_/g, ' ')` so `garage_door` displays as "Garage Door (1)" under the existing `text-transform: capitalize`.

## Test plan

- [x] 2 new tests in `action-editor.test.ts`:
  - Renders categories returned by the backend even when not in the legacy allowlist (the bug fix; failed against prior code with `expected a "garage door" category header, got: []`).
  - Skips categories with zero sensors (characterization of existing correct filter, locked in across the loop change).
- [x] All 36 tests pass; `tsc --noEmit` clean.

## Coordination

The exported `SensorCategory` literal union is now orphaned — kept around for PR7 (#33), which will turn it into a typed iterator + friendly-label map. The `text-transform: capitalize` + `replace(/_/g, ' ')` fallback gives reasonable labels until then.

Closes #25.
