### PR TITLE
refactor(frontend): extract <abode-modal> to dedupe three dialogs (fixes #32)

### DIFF
--- a/custom_components/abode_security/www/abode-security-panel.js
+++ b/custom_components/abode_security/www/abode-security-panel.js
@@ -1,8 +1,8 @@
-function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPropertyDescriptor(e,i):o;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)a=Reflect.decorate(t,e,i,o);else for(var n=t.length-1;n>=0;n--)(s=t[n])&&(a=(r<3?s(a):r>3?s(e,i,a):s(e,i))||a);return r>3&&a&&Object.defineProperty(e,i,a),a}"function"==typeof SuppressedError&&SuppressedError;const e=globalThis,i=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,o=Symbol(),s=new WeakMap;let r=class{constructor(t,e,i){if(this._$cssResult$=!0,i!==o)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=e}get styleSheet(){let t=this.o;const e=this.t;if(i&&void 0===t){const i=void 0!==e&&1===e.length;i&&(t=s.get(e)),void 0===t&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),i&&s.set(e,t))}return t}toString(){return this.cssText}};const a=(t,...e)=>{const i=1===t.length?t[0]:e.reduce((e,i,o)=>e+(t=>{if(!0===t._$cssResult$)return t.cssText;if("number"==typeof t)return t;throw Error("Value passed to 'css' function must be a 'css' function result: "+t+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+t[o+1],t[0]);return new r(i,t,o)},n=i?t=>t:t=>t instanceof CSSStyleSheet?(t=>{let e="";for(const i of t.cssRules)e+=i.cssText;return(t=>new r("string"==typeof t?t:t+"",void 0,o))(e)})(t):t,{is:l,defineProperty:c,getOwnPropertyDescriptor:d,getOwnPropertyNames:h,getOwnPropertySymbols:p,getPrototypeOf:g}=Object,u=globalThis,_=u.trustedTypes,m=_?_.emptyScript:"",b=u.reactiveElementPolyfillSupport,f=(t,e)=>t,y={toAttribute(t,e){switch(e){case Boolean:t=t?m:null;break;case Object:case Array:t=null==t?t:JSON.stringify(t)}return t},fromAttribute(t,e){let i=t;switch(e){case Boolean:i=null!==t;break;case Number:i=null===t?null:Number(t);break;case Object:case Array:try{i=JSON.parse(t)}catch(t){i=null}}return i}},v=(t,e)=>!l(t,e),x={attribute:!0,type:String,converter:y,reflect:!1,useDefault:!1,hasChanged:v};Symbol.metadata??=Symbol("metadata"),u.litPropertyMetadata??=new WeakMap;let $=class extends HTMLElement{static addInitializer(t){this._$Ei(),(this.l??=[]).push(t)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(t,e=x){if(e.state&&(e.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(t)&&((e=Object.create(e)).wrapped=!0),this.elementProperties.set(t,e),!e.noAccessor){const i=Symbol(),o=this.getPropertyDescriptor(t,i,e);void 0!==o&&c(this.prototype,t,o)}}static getPropertyDescriptor(t,e,i){const{get:o,set:s}=d(this.prototype,t)??{get(){return this[e]},set(t){this[e]=t}};return{get:o,set(e){const r=o?.call(this);s?.call(this,e),this.requestUpdate(t,r,i)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)??x}static _$Ei(){if(this.hasOwnProperty(f("elementProperties")))return;const t=g(this);t.finalize(),void 0!==t.l&&(this.l=[...t.l]),this.elementProperties=new Map(t.elementProperties)}static finalize(){if(this.hasOwnProperty(f("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(f("properties"))){const t=this.properties,e=[...h(t),...p(t)];for(const i of e)this.createProperty(i,t[i])}const t=this[Symbol.metadata];if(null!==t){const e=litPropertyMetadata.get(t);if(void 0!==e)for(const[t,i]of e)this.elementProperties.set(t,i)}this._$Eh=new Map;for(const[t,e]of this.elementProperties){const i=this._$Eu(t,e);void 0!==i&&this._$Eh.set(i,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(t){const e=[];if(Array.isArray(t)){const i=new Set(t.flat(1/0).reverse());for(const t of i)e.unshift(n(t))}else void 0!==t&&e.push(n(t));return e}static _$Eu(t,e){const i=e.attribute;return!1===i?void 0:"string"==typeof i?i:"string"==typeof t?t.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(t=>t(this))}addController(t){(this._$EO??=new Set).add(t),void 0!==this.renderRoot&&this.isConnected&&t.hostConnected?.()}removeController(t){this._$EO?.delete(t)}_$E_(){const t=new Map,e=this.constructor.elementProperties;for(const i of e.keys())this.hasOwnProperty(i)&&(t.set(i,this[i]),delete this[i]);t.size>0&&(this._$Ep=t)}createRenderRoot(){const t=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((t,o)=>{if(i)t.adoptedStyleSheets=o.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(const i of o){const o=document.createElement("style"),s=e.litNonce;void 0!==s&&o.setAttribute("nonce",s),o.textContent=i.cssText,t.appendChild(o)}})(t,this.constructor.elementStyles),t}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(t=>t.hostConnected?.())}enableUpdating(t){}disconnectedCallback(){this._$EO?.forEach(t=>t.hostDisconnected?.())}attributeChangedCallback(t,e,i){this._$AK(t,i)}_$ET(t,e){const i=this.constructor.elementProperties.get(t),o=this.constructor._$Eu(t,i);if(void 0!==o&&!0===i.reflect){const s=(void 0!==i.converter?.toAttribute?i.converter:y).toAttribute(e,i.type);this._$Em=t,null==s?this.removeAttribute(o):this.setAttribute(o,s),this._$Em=null}}_$AK(t,e){const i=this.constructor,o=i._$Eh.get(t);if(void 0!==o&&this._$Em!==o){const t=i.getPropertyOptions(o),s="function"==typeof t.converter?{fromAttribute:t.converter}:void 0!==t.converter?.fromAttribute?t.converter:y;this._$Em=o;const r=s.fromAttribute(e,t.type);this[o]=r??this._$Ej?.get(o)??r,this._$Em=null}}requestUpdate(t,e,i,o=!1,s){if(void 0!==t){const r=this.constructor;if(!1===o&&(s=this[t]),i??=r.getPropertyOptions(t),!((i.hasChanged??v)(s,e)||i.useDefault&&i.reflect&&s===this._$Ej?.get(t)&&!this.hasAttribute(r._$Eu(t,i))))return;this.C(t,e,i)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(t,e,{useDefault:i,reflect:o,wrapped:s},r){i&&!(this._$Ej??=new Map).has(t)&&(this._$Ej.set(t,r??e??this[t]),!0!==s||void 0!==r)||(this._$AL.has(t)||(this.hasUpdated||i||(e=void 0),this._$AL.set(t,e)),!0===o&&this._$Em!==t&&(this._$Eq??=new Set).add(t))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}const t=this.scheduleUpdate();return null!=t&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[t,e]of this._$Ep)this[t]=e;this._$Ep=void 0}const t=this.constructor.elementProperties;if(t.size>0)for(const[e,i]of t){const{wrapped:t}=i,o=this[e];!0!==t||this._$AL.has(e)||void 0===o||this.C(e,void 0,i,o)}}let t=!1;const e=this._$AL;try{t=this.shouldUpdate(e),t?(this.willUpdate(e),this._$EO?.forEach(t=>t.hostUpdate?.()),this.update(e)):this._$EM()}catch(e){throw t=!1,this._$EM(),e}t&&this._$AE(e)}willUpdate(t){}_$AE(t){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(t){return!0}update(t){this._$Eq&&=this._$Eq.forEach(t=>this._$ET(t,this[t])),this._$EM()}updated(t){}firstUpdated(t){}};$.elementStyles=[],$.shadowRootOptions={mode:"open"},$[f("elementProperties")]=new Map,$[f("finalized")]=new Map,b?.({ReactiveElement:$}),(u.reactiveElementVersions??=[]).push("2.1.2");const w=globalThis,A=t=>t,S=w.trustedTypes,k=S?S.createPolicy("lit-html",{createHTML:t=>t}):void 0,E="$lit$",C=`lit$${Math.random().toFixed(9).slice(2)}$`,T="?"+C,P=`<${T}>`,D=document,z=()=>D.createComment(""),M=t=>null===t||"object"!=typeof t&&"function"!=typeof t,O=Array.isArray,U="[ \t\n\f\r]",N=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,R=/-->/g,H=/>/g,j=RegExp(`>|${U}(?:([^\\s"'>=/]+)(${U}*=${U}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),I=/'/g,L=/"/g,F=/^(?:script|style|textarea|title)$/i,q=(t=>(e,...i)=>({_$litType$:t,strings:e,values:i}))(1),W=Symbol.for("lit-noChange"),B=Symbol.for("lit-nothing"),V=new WeakMap,K=D.createTreeWalker(D,129);function J(t,e){if(!O(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==k?k.createHTML(e):e}const Z=(t,e)=>{const i=t.length-1,o=[];let s,r=2===e?"<svg>":3===e?"<math>":"",a=N;for(let e=0;e<i;e++){const i=t[e];let n,l,c=-1,d=0;for(;d<i.length&&(a.lastIndex=d,l=a.exec(i),null!==l);)d=a.lastIndex,a===N?"!--"===l[1]?a=R:void 0!==l[1]?a=H:void 0!==l[2]?(F.test(l[2])&&(s=RegExp("</"+l[2],"g")),a=j):void 0!==l[3]&&(a=j):a===j?">"===l[0]?(a=s??N,c=-1):void 0===l[1]?c=-2:(c=a.lastIndex-l[2].length,n=l[1],a=void 0===l[3]?j:'"'===l[3]?L:I):a===L||a===I?a=j:a===R||a===H?a=N:(a=j,s=void 0);const h=a===j&&t[e+1].startsWith("/>")?" ":"";r+=a===N?i+P:c>=0?(o.push(n),i.slice(0,c)+E+i.slice(c)+C+h):i+C+(-2===c?e:h)}return[J(t,r+(t[i]||"<?>")+(2===e?"</svg>":3===e?"</math>":"")),o]};class X{constructor({strings:t,_$litType$:e},i){let o;this.parts=[];let s=0,r=0;const a=t.length-1,n=this.parts,[l,c]=Z(t,e);if(this.el=X.createElement(l,i),K.currentNode=this.el.content,2===e||3===e){const t=this.el.content.firstChild;t.replaceWith(...t.childNodes)}for(;null!==(o=K.nextNode())&&n.length<a;){if(1===o.nodeType){if(o.hasAttributes())for(const t of o.getAttributeNames())if(t.endsWith(E)){const e=c[r++],i=o.getAttribute(t).split(C),a=/([.?@])?(.*)/.exec(e);n.push({type:1,index:s,name:a[2],strings:i,ctor:"."===a[1]?et:"?"===a[1]?it:"@"===a[1]?ot:tt}),o.removeAttribute(t)}else t.startsWith(C)&&(n.push({type:6,index:s}),o.removeAttribute(t));if(F.test(o.tagName)){const t=o.textContent.split(C),e=t.length-1;if(e>0){o.textContent=S?S.emptyScript:"";for(let i=0;i<e;i++)o.append(t[i],z()),K.nextNode(),n.push({type:2,index:++s});o.append(t[e],z())}}}else if(8===o.nodeType)if(o.data===T)n.push({type:2,index:s});else{let t=-1;for(;-1!==(t=o.data.indexOf(C,t+1));)n.push({type:7,index:s}),t+=C.length-1}s++}}static createElement(t,e){const i=D.createElement("template");return i.innerHTML=t,i}}function G(t,e,i=t,o){if(e===W)return e;let s=void 0!==o?i._$Co?.[o]:i._$Cl;const r=M(e)?void 0:e._$litDirective$;return s?.constructor!==r&&(s?._$AO?.(!1),void 0===r?s=void 0:(s=new r(t),s._$AT(t,i,o)),void 0!==o?(i._$Co??=[])[o]=s:i._$Cl=s),void 0!==s&&(e=G(t,s._$AS(t,e.values),s,o)),e}class Q{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){const{el:{content:e},parts:i}=this._$AD,o=(t?.creationScope??D).importNode(e,!0);K.currentNode=o;let s=K.nextNode(),r=0,a=0,n=i[0];for(;void 0!==n;){if(r===n.index){let e;2===n.type?e=new Y(s,s.nextSibling,this,t):1===n.type?e=new n.ctor(s,n.name,n.strings,this,t):6===n.type&&(e=new st(s,this,t)),this._$AV.push(e),n=i[++a]}r!==n?.index&&(s=K.nextNode(),r++)}return K.currentNode=D,o}p(t){let e=0;for(const i of this._$AV)void 0!==i&&(void 0!==i.strings?(i._$AI(t,i,e),e+=i.strings.length-2):i._$AI(t[e])),e++}}class Y{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,e,i,o){this.type=2,this._$AH=B,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=i,this.options=o,this._$Cv=o?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===t?.nodeType&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=G(this,t,e),M(t)?t===B||null==t||""===t?(this._$AH!==B&&this._$AR(),this._$AH=B):t!==this._$AH&&t!==W&&this._(t):void 0!==t._$litType$?this.$(t):void 0!==t.nodeType?this.T(t):(t=>O(t)||"function"==typeof t?.[Symbol.iterator])(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==B&&M(this._$AH)?this._$AA.nextSibling.data=t:this.T(D.createTextNode(t)),this._$AH=t}$(t){const{values:e,_$litType$:i}=t,o="number"==typeof i?this._$AC(t):(void 0===i.el&&(i.el=X.createElement(J(i.h,i.h[0]),this.options)),i);if(this._$AH?._$AD===o)this._$AH.p(e);else{const t=new Q(o,this),i=t.u(this.options);t.p(e),this.T(i),this._$AH=t}}_$AC(t){let e=V.get(t.strings);return void 0===e&&V.set(t.strings,e=new X(t)),e}k(t){O(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let i,o=0;for(const s of t)o===e.length?e.push(i=new Y(this.O(z()),this.O(z()),this,this.options)):i=e[o],i._$AI(s),o++;o<e.length&&(this._$AR(i&&i._$AB.nextSibling,o),e.length=o)}_$AR(t=this._$AA.nextSibling,e){for(this._$AP?.(!1,!0,e);t!==this._$AB;){const e=A(t).nextSibling;A(t).remove(),t=e}}setConnected(t){void 0===this._$AM&&(this._$Cv=t,this._$AP?.(t))}}class tt{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,e,i,o,s){this.type=1,this._$AH=B,this._$AN=void 0,this.element=t,this.name=e,this._$AM=o,this.options=s,i.length>2||""!==i[0]||""!==i[1]?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=B}_$AI(t,e=this,i,o){const s=this.strings;let r=!1;if(void 0===s)t=G(this,t,e,0),r=!M(t)||t!==this._$AH&&t!==W,r&&(this._$AH=t);else{const o=t;let a,n;for(t=s[0],a=0;a<s.length-1;a++)n=G(this,o[i+a],e,a),n===W&&(n=this._$AH[a]),r||=!M(n)||n!==this._$AH[a],n===B?t=B:t!==B&&(t+=(n??"")+s[a+1]),this._$AH[a]=n}r&&!o&&this.j(t)}j(t){t===B?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}}class et extends tt{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===B?void 0:t}}class it extends tt{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==B)}}class ot extends tt{constructor(t,e,i,o,s){super(t,e,i,o,s),this.type=5}_$AI(t,e=this){if((t=G(this,t,e,0)??B)===W)return;const i=this._$AH,o=t===B&&i!==B||t.capture!==i.capture||t.once!==i.once||t.passive!==i.passive,s=t!==B&&(i===B||o);o&&this.element.removeEventListener(this.name,this,i),s&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}}class st{constructor(t,e,i){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(t){G(this,t)}}const rt=w.litHtmlPolyfillSupport;rt?.(X,Y),(w.litHtmlVersions??=[]).push("3.3.2");const at=globalThis;class nt extends ${constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const t=super.createRenderRoot();return this.renderOptions.renderBefore??=t.firstChild,t}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,i)=>{const o=i?.renderBefore??e;let s=o._$litPart$;if(void 0===s){const t=i?.renderBefore??null;o._$litPart$=s=new Y(e.insertBefore(z(),t),t,void 0,i??{})}return s._$AI(t),s})(e,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return W}}nt._$litElement$=!0,nt.finalized=!0,at.litElementHydrateSupport?.({LitElement:nt});const lt=at.litElementPolyfillSupport;lt?.({LitElement:nt}),(at.litElementVersions??=[]).push("4.2.2");const ct=t=>(e,i)=>{void 0!==i?i.addInitializer(()=>{customElements.define(t,e)}):customElements.define(t,e)},dt={attribute:!0,type:String,converter:y,reflect:!1,hasChanged:v},ht=(t=dt,e,i)=>{const{kind:o,metadata:s}=i;let r=globalThis.litPropertyMetadata.get(s);if(void 0===r&&globalThis.litPropertyMetadata.set(s,r=new Map),"setter"===o&&((t=Object.create(t)).wrapped=!0),r.set(i.name,t),"accessor"===o){const{name:o}=i;return{set(i){const s=e.get.call(this);e.set.call(this,i),this.requestUpdate(o,s,t,!0,i)},init(e){return void 0!==e&&this.C(o,void 0,t,e),e}}}if("setter"===o){const{name:o}=i;return function(i){const s=this[o];e.call(this,i),this.requestUpdate(o,s,t,!0,i)}}throw Error("Unsupported decorator location: "+o)};function pt(t){return(e,i)=>"object"==typeof i?ht(t,e,i):((t,e,i)=>{const o=e.hasOwnProperty(i);return e.constructor.createProperty(i,t),o?Object.getOwnPropertyDescriptor(e,i):void 0})(t,e,i)}function gt(t){return pt({...t,state:!0,attribute:!1})}async function ut(t){return(await t.callWS({type:"abode_security/actions/list"})).actions}async function _t(t){return(await t.callWS({type:"abode_security/modes/list"})).modes}async function mt(t){return(await t.callWS({type:"abode_security/entities/sensors"})).sensors}async function bt(t){return(await t.callWS({type:"abode_security/entities/alarms"})).alarms}async function ft(t,e,i){return(await t.callWS({type:"abode_security/actions/update",action_id:e,...i})).action}let yt=class extends nt{constructor(){super(...arguments),this._modes=[],this._actions=[],this._loading=!0,this._error=null}async connectedCallback(){super.connectedCallback(),await this._loadData()}async _loadData(){this._loading=!0,this._error=null;try{const[t,e]=await Promise.all([_t(this.hass),ut(this.hass)]);this._modes=t??[],this._actions=e??[]}catch(t){this._error=t instanceof Error?t.message:"Failed to load data"}finally{this._loading=!1}}_getActionsForMode(t){return this._actions.filter(e=>e.enabled&&e.modes.includes(t))}render(){return this._loading?q`<div class="loading">Loading modes...</div>`:this._error?q`<div class="error" role="alert">${this._error}</div>`:q`
+function t(t,e,o,i){var s,r=arguments.length,a=r<3?e:null===i?i=Object.getOwnPropertyDescriptor(e,o):i;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)a=Reflect.decorate(t,e,o,i);else for(var n=t.length-1;n>=0;n--)(s=t[n])&&(a=(r<3?s(a):r>3?s(e,o,a):s(e,o))||a);return r>3&&a&&Object.defineProperty(e,o,a),a}"function"==typeof SuppressedError&&SuppressedError;const e=globalThis,o=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,i=Symbol(),s=new WeakMap;let r=class{constructor(t,e,o){if(this._$cssResult$=!0,o!==i)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=e}get styleSheet(){let t=this.o;const e=this.t;if(o&&void 0===t){const o=void 0!==e&&1===e.length;o&&(t=s.get(e)),void 0===t&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),o&&s.set(e,t))}return t}toString(){return this.cssText}};const a=(t,...e)=>{const o=1===t.length?t[0]:e.reduce((e,o,i)=>e+(t=>{if(!0===t._$cssResult$)return t.cssText;if("number"==typeof t)return t;throw Error("Value passed to 'css' function must be a 'css' function result: "+t+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(o)+t[i+1],t[0]);return new r(o,t,i)},n=o?t=>t:t=>t instanceof CSSStyleSheet?(t=>{let e="";for(const o of t.cssRules)e+=o.cssText;return(t=>new r("string"==typeof t?t:t+"",void 0,i))(e)})(t):t,{is:l,defineProperty:c,getOwnPropertyDescriptor:d,getOwnPropertyNames:h,getOwnPropertySymbols:p,getPrototypeOf:u}=Object,g=globalThis,m=g.trustedTypes,_=m?m.emptyScript:"",b=g.reactiveElementPolyfillSupport,f=(t,e)=>t,y={toAttribute(t,e){switch(e){case Boolean:t=t?_:null;break;case Object:case Array:t=null==t?t:JSON.stringify(t)}return t},fromAttribute(t,e){let o=t;switch(e){case Boolean:o=null!==t;break;case Number:o=null===t?null:Number(t);break;case Object:case Array:try{o=JSON.parse(t)}catch(t){o=null}}return o}},v=(t,e)=>!l(t,e),x={attribute:!0,type:String,converter:y,reflect:!1,useDefault:!1,hasChanged:v};Symbol.metadata??=Symbol("metadata"),g.litPropertyMetadata??=new WeakMap;let $=class extends HTMLElement{static addInitializer(t){this._$Ei(),(this.l??=[]).push(t)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(t,e=x){if(e.state&&(e.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(t)&&((e=Object.create(e)).wrapped=!0),this.elementProperties.set(t,e),!e.noAccessor){const o=Symbol(),i=this.getPropertyDescriptor(t,o,e);void 0!==i&&c(this.prototype,t,i)}}static getPropertyDescriptor(t,e,o){const{get:i,set:s}=d(this.prototype,t)??{get(){return this[e]},set(t){this[e]=t}};return{get:i,set(e){const r=i?.call(this);s?.call(this,e),this.requestUpdate(t,r,o)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)??x}static _$Ei(){if(this.hasOwnProperty(f("elementProperties")))return;const t=u(this);t.finalize(),void 0!==t.l&&(this.l=[...t.l]),this.elementProperties=new Map(t.elementProperties)}static finalize(){if(this.hasOwnProperty(f("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(f("properties"))){const t=this.properties,e=[...h(t),...p(t)];for(const o of e)this.createProperty(o,t[o])}const t=this[Symbol.metadata];if(null!==t){const e=litPropertyMetadata.get(t);if(void 0!==e)for(const[t,o]of e)this.elementProperties.set(t,o)}this._$Eh=new Map;for(const[t,e]of this.elementProperties){const o=this._$Eu(t,e);void 0!==o&&this._$Eh.set(o,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(t){const e=[];if(Array.isArray(t)){const o=new Set(t.flat(1/0).reverse());for(const t of o)e.unshift(n(t))}else void 0!==t&&e.push(n(t));return e}static _$Eu(t,e){const o=e.attribute;return!1===o?void 0:"string"==typeof o?o:"string"==typeof t?t.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(t=>t(this))}addController(t){(this._$EO??=new Set).add(t),void 0!==this.renderRoot&&this.isConnected&&t.hostConnected?.()}removeController(t){this._$EO?.delete(t)}_$E_(){const t=new Map,e=this.constructor.elementProperties;for(const o of e.keys())this.hasOwnProperty(o)&&(t.set(o,this[o]),delete this[o]);t.size>0&&(this._$Ep=t)}createRenderRoot(){const t=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((t,i)=>{if(o)t.adoptedStyleSheets=i.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(const o of i){const i=document.createElement("style"),s=e.litNonce;void 0!==s&&i.setAttribute("nonce",s),i.textContent=o.cssText,t.appendChild(i)}})(t,this.constructor.elementStyles),t}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(t=>t.hostConnected?.())}enableUpdating(t){}disconnectedCallback(){this._$EO?.forEach(t=>t.hostDisconnected?.())}attributeChangedCallback(t,e,o){this._$AK(t,o)}_$ET(t,e){const o=this.constructor.elementProperties.get(t),i=this.constructor._$Eu(t,o);if(void 0!==i&&!0===o.reflect){const s=(void 0!==o.converter?.toAttribute?o.converter:y).toAttribute(e,o.type);this._$Em=t,null==s?this.removeAttribute(i):this.setAttribute(i,s),this._$Em=null}}_$AK(t,e){const o=this.constructor,i=o._$Eh.get(t);if(void 0!==i&&this._$Em!==i){const t=o.getPropertyOptions(i),s="function"==typeof t.converter?{fromAttribute:t.converter}:void 0!==t.converter?.fromAttribute?t.converter:y;this._$Em=i;const r=s.fromAttribute(e,t.type);this[i]=r??this._$Ej?.get(i)??r,this._$Em=null}}requestUpdate(t,e,o,i=!1,s){if(void 0!==t){const r=this.constructor;if(!1===i&&(s=this[t]),o??=r.getPropertyOptions(t),!((o.hasChanged??v)(s,e)||o.useDefault&&o.reflect&&s===this._$Ej?.get(t)&&!this.hasAttribute(r._$Eu(t,o))))return;this.C(t,e,o)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(t,e,{useDefault:o,reflect:i,wrapped:s},r){o&&!(this._$Ej??=new Map).has(t)&&(this._$Ej.set(t,r??e??this[t]),!0!==s||void 0!==r)||(this._$AL.has(t)||(this.hasUpdated||o||(e=void 0),this._$AL.set(t,e)),!0===i&&this._$Em!==t&&(this._$Eq??=new Set).add(t))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}const t=this.scheduleUpdate();return null!=t&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[t,e]of this._$Ep)this[t]=e;this._$Ep=void 0}const t=this.constructor.elementProperties;if(t.size>0)for(const[e,o]of t){const{wrapped:t}=o,i=this[e];!0!==t||this._$AL.has(e)||void 0===i||this.C(e,void 0,o,i)}}let t=!1;const e=this._$AL;try{t=this.shouldUpdate(e),t?(this.willUpdate(e),this._$EO?.forEach(t=>t.hostUpdate?.()),this.update(e)):this._$EM()}catch(e){throw t=!1,this._$EM(),e}t&&this._$AE(e)}willUpdate(t){}_$AE(t){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(t){return!0}update(t){this._$Eq&&=this._$Eq.forEach(t=>this._$ET(t,this[t])),this._$EM()}updated(t){}firstUpdated(t){}};$.elementStyles=[],$.shadowRootOptions={mode:"open"},$[f("elementProperties")]=new Map,$[f("finalized")]=new Map,b?.({ReactiveElement:$}),(g.reactiveElementVersions??=[]).push("2.1.2");const A=globalThis,w=t=>t,S=A.trustedTypes,E=S?S.createPolicy("lit-html",{createHTML:t=>t}):void 0,k="$lit$",C=`lit$${Math.random().toFixed(9).slice(2)}$`,T="?"+C,P=`<${T}>`,z=document,O=()=>z.createComment(""),M=t=>null===t||"object"!=typeof t&&"function"!=typeof t,U=Array.isArray,D="[ \t\n\f\r]",N=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,R=/-->/g,H=/>/g,j=RegExp(`>|${D}(?:([^\\s"'>=/]+)(${D}*=${D}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),F=/'/g,I=/"/g,B=/^(?:script|style|textarea|title)$/i,L=(t=>(e,...o)=>({_$litType$:t,strings:e,values:o}))(1),q=Symbol.for("lit-noChange"),W=Symbol.for("lit-nothing"),V=new WeakMap,K=z.createTreeWalker(z,129);function J(t,e){if(!U(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==E?E.createHTML(e):e}class Z{constructor({strings:t,_$litType$:e},o){let i;this.parts=[];let s=0,r=0;const a=t.length-1,n=this.parts,[l,c]=((t,e)=>{const o=t.length-1,i=[];let s,r=2===e?"<svg>":3===e?"<math>":"",a=N;for(let e=0;e<o;e++){const o=t[e];let n,l,c=-1,d=0;for(;d<o.length&&(a.lastIndex=d,l=a.exec(o),null!==l);)d=a.lastIndex,a===N?"!--"===l[1]?a=R:void 0!==l[1]?a=H:void 0!==l[2]?(B.test(l[2])&&(s=RegExp("</"+l[2],"g")),a=j):void 0!==l[3]&&(a=j):a===j?">"===l[0]?(a=s??N,c=-1):void 0===l[1]?c=-2:(c=a.lastIndex-l[2].length,n=l[1],a=void 0===l[3]?j:'"'===l[3]?I:F):a===I||a===F?a=j:a===R||a===H?a=N:(a=j,s=void 0);const h=a===j&&t[e+1].startsWith("/>")?" ":"";r+=a===N?o+P:c>=0?(i.push(n),o.slice(0,c)+k+o.slice(c)+C+h):o+C+(-2===c?e:h)}return[J(t,r+(t[o]||"<?>")+(2===e?"</svg>":3===e?"</math>":"")),i]})(t,e);if(this.el=Z.createElement(l,o),K.currentNode=this.el.content,2===e||3===e){const t=this.el.content.firstChild;t.replaceWith(...t.childNodes)}for(;null!==(i=K.nextNode())&&n.length<a;){if(1===i.nodeType){if(i.hasAttributes())for(const t of i.getAttributeNames())if(t.endsWith(k)){const e=c[r++],o=i.getAttribute(t).split(C),a=/([.?@])?(.*)/.exec(e);n.push({type:1,index:s,name:a[2],strings:o,ctor:"."===a[1]?tt:"?"===a[1]?et:"@"===a[1]?ot:Y}),i.removeAttribute(t)}else t.startsWith(C)&&(n.push({type:6,index:s}),i.removeAttribute(t));if(B.test(i.tagName)){const t=i.textContent.split(C),e=t.length-1;if(e>0){i.textContent=S?S.emptyScript:"";for(let o=0;o<e;o++)i.append(t[o],O()),K.nextNode(),n.push({type:2,index:++s});i.append(t[e],O())}}}else if(8===i.nodeType)if(i.data===T)n.push({type:2,index:s});else{let t=-1;for(;-1!==(t=i.data.indexOf(C,t+1));)n.push({type:7,index:s}),t+=C.length-1}s++}}static createElement(t,e){const o=z.createElement("template");return o.innerHTML=t,o}}function Q(t,e,o=t,i){if(e===q)return e;let s=void 0!==i?o._$Co?.[i]:o._$Cl;const r=M(e)?void 0:e._$litDirective$;return s?.constructor!==r&&(s?._$AO?.(!1),void 0===r?s=void 0:(s=new r(t),s._$AT(t,o,i)),void 0!==i?(o._$Co??=[])[i]=s:o._$Cl=s),void 0!==s&&(e=Q(t,s._$AS(t,e.values),s,i)),e}class X{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){const{el:{content:e},parts:o}=this._$AD,i=(t?.creationScope??z).importNode(e,!0);K.currentNode=i;let s=K.nextNode(),r=0,a=0,n=o[0];for(;void 0!==n;){if(r===n.index){let e;2===n.type?e=new G(s,s.nextSibling,this,t):1===n.type?e=new n.ctor(s,n.name,n.strings,this,t):6===n.type&&(e=new it(s,this,t)),this._$AV.push(e),n=o[++a]}r!==n?.index&&(s=K.nextNode(),r++)}return K.currentNode=z,i}p(t){let e=0;for(const o of this._$AV)void 0!==o&&(void 0!==o.strings?(o._$AI(t,o,e),e+=o.strings.length-2):o._$AI(t[e])),e++}}class G{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,e,o,i){this.type=2,this._$AH=W,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=o,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===t?.nodeType&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=Q(this,t,e),M(t)?t===W||null==t||""===t?(this._$AH!==W&&this._$AR(),this._$AH=W):t!==this._$AH&&t!==q&&this._(t):void 0!==t._$litType$?this.$(t):void 0!==t.nodeType?this.T(t):(t=>U(t)||"function"==typeof t?.[Symbol.iterator])(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==W&&M(this._$AH)?this._$AA.nextSibling.data=t:this.T(z.createTextNode(t)),this._$AH=t}$(t){const{values:e,_$litType$:o}=t,i="number"==typeof o?this._$AC(t):(void 0===o.el&&(o.el=Z.createElement(J(o.h,o.h[0]),this.options)),o);if(this._$AH?._$AD===i)this._$AH.p(e);else{const t=new X(i,this),o=t.u(this.options);t.p(e),this.T(o),this._$AH=t}}_$AC(t){let e=V.get(t.strings);return void 0===e&&V.set(t.strings,e=new Z(t)),e}k(t){U(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let o,i=0;for(const s of t)i===e.length?e.push(o=new G(this.O(O()),this.O(O()),this,this.options)):o=e[i],o._$AI(s),i++;i<e.length&&(this._$AR(o&&o._$AB.nextSibling,i),e.length=i)}_$AR(t=this._$AA.nextSibling,e){for(this._$AP?.(!1,!0,e);t!==this._$AB;){const e=w(t).nextSibling;w(t).remove(),t=e}}setConnected(t){void 0===this._$AM&&(this._$Cv=t,this._$AP?.(t))}}class Y{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,e,o,i,s){this.type=1,this._$AH=W,this._$AN=void 0,this.element=t,this.name=e,this._$AM=i,this.options=s,o.length>2||""!==o[0]||""!==o[1]?(this._$AH=Array(o.length-1).fill(new String),this.strings=o):this._$AH=W}_$AI(t,e=this,o,i){const s=this.strings;let r=!1;if(void 0===s)t=Q(this,t,e,0),r=!M(t)||t!==this._$AH&&t!==q,r&&(this._$AH=t);else{const i=t;let a,n;for(t=s[0],a=0;a<s.length-1;a++)n=Q(this,i[o+a],e,a),n===q&&(n=this._$AH[a]),r||=!M(n)||n!==this._$AH[a],n===W?t=W:t!==W&&(t+=(n??"")+s[a+1]),this._$AH[a]=n}r&&!i&&this.j(t)}j(t){t===W?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}}class tt extends Y{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===W?void 0:t}}class et extends Y{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==W)}}class ot extends Y{constructor(t,e,o,i,s){super(t,e,o,i,s),this.type=5}_$AI(t,e=this){if((t=Q(this,t,e,0)??W)===q)return;const o=this._$AH,i=t===W&&o!==W||t.capture!==o.capture||t.once!==o.once||t.passive!==o.passive,s=t!==W&&(o===W||i);i&&this.element.removeEventListener(this.name,this,o),s&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}}class it{constructor(t,e,o){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=o}get _$AU(){return this._$AM._$AU}_$AI(t){Q(this,t)}}const st={I:G},rt=A.litHtmlPolyfillSupport;rt?.(Z,G),(A.litHtmlVersions??=[]).push("3.3.2");const at=globalThis;let nt=class extends ${constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const t=super.createRenderRoot();return this.renderOptions.renderBefore??=t.firstChild,t}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,o)=>{const i=o?.renderBefore??e;let s=i._$litPart$;if(void 0===s){const t=o?.renderBefore??null;i._$litPart$=s=new G(e.insertBefore(O(),t),t,void 0,o??{})}return s._$AI(t),s})(e,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return q}};nt._$litElement$=!0,nt.finalized=!0,at.litElementHydrateSupport?.({LitElement:nt});const lt=at.litElementPolyfillSupport;lt?.({LitElement:nt}),(at.litElementVersions??=[]).push("4.2.2");const ct=t=>(e,o)=>{void 0!==o?o.addInitializer(()=>{customElements.define(t,e)}):customElements.define(t,e)},dt={attribute:!0,type:String,converter:y,reflect:!1,hasChanged:v},ht=(t=dt,e,o)=>{const{kind:i,metadata:s}=o;let r=globalThis.litPropertyMetadata.get(s);if(void 0===r&&globalThis.litPropertyMetadata.set(s,r=new Map),"setter"===i&&((t=Object.create(t)).wrapped=!0),r.set(o.name,t),"accessor"===i){const{name:i}=o;return{set(o){const s=e.get.call(this);e.set.call(this,o),this.requestUpdate(i,s,t,!0,o)},init(e){return void 0!==e&&this.C(i,void 0,t,e),e}}}if("setter"===i){const{name:i}=o;return function(o){const s=this[i];e.call(this,o),this.requestUpdate(i,s,t,!0,o)}}throw Error("Unsupported decorator location: "+i)};function pt(t){return(e,o)=>"object"==typeof o?ht(t,e,o):((t,e,o)=>{const i=e.hasOwnProperty(o);return e.constructor.createProperty(o,t),i?Object.getOwnPropertyDescriptor(e,o):void 0})(t,e,o)}function ut(t){return pt({...t,state:!0,attribute:!1})}async function gt(t){return(await t.callWS({type:"abode_security/actions/list"})).actions}async function mt(t){return(await t.callWS({type:"abode_security/modes/list"})).modes}async function _t(t){return(await t.callWS({type:"abode_security/entities/sensors"})).sensors}async function bt(t){return(await t.callWS({type:"abode_security/entities/alarms"})).alarms}async function ft(t,e,o){return t.callWS({type:"abode_security/actions/update",action_id:e,...o})}let yt=class extends nt{constructor(){super(...arguments),this._modes=[],this._actions=[],this._loading=!0,this._error=null}async connectedCallback(){super.connectedCallback(),await this._loadData()}async _loadData(){this._loading=!0,this._error=null;try{const[t,e]=await Promise.all([mt(this.hass),gt(this.hass)]);this._modes=t??[],this._actions=e??[]}catch(t){this._error=t instanceof Error?t.message:"Failed to load data"}finally{this._loading=!1}}_getActionsForMode(t){return this._actions.filter(e=>e.enabled&&e.modes.includes(t))}render(){return this._loading?L`<div class="loading">Loading modes...</div>`:this._error?L`<div class="error" role="alert">${this._error}</div>`:L`
       <div class="modes-grid">
         ${this._modes.map(t=>this._renderModeCard(t))}
       </div>
-    `}_renderModeCard(t){const e=this._getActionsForMode(t.id);return q`
+    `}_renderModeCard(t){const e=this._getActionsForMode(t.id);return L`
       <div class="mode-card ${t.active?"active":""}">
         <div class="mode-header">
           <div class="mode-icon">
@@ -12,21 +12,21 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
             <h3>${t.name}</h3>
             <div class="badges">
               <span class="badge">${t.action_count} actions</span>
-              ${t.active?q`<span class="badge active">Active</span>`:""}
+              ${t.active?L`<span class="badge active">Active</span>`:""}
             </div>
           </div>
         </div>
 
-        ${e.length>0?q`
+        ${e.length>0?L`
               <ul class="action-list" aria-label="Actions for ${t.name} mode">
-                ${e.map(t=>q`
+                ${e.map(t=>L`
                     <li>
                       <ha-icon icon="mdi:bell-ring"></ha-icon>
                       ${t.name}
                     </li>
                   `)}
               </ul>
-            `:q`<div class="empty-actions">No actions configured</div>`}
+            `:L`<div class="empty-actions">No actions configured</div>`}
       </div>
     `}};yt.styles=a`
     :host {
@@ -150,19 +150,106 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
       color: white;
       border-radius: 4px;
     }
-  `,t([pt({attribute:!1})],yt.prototype,"hass",void 0),t([gt()],yt.prototype,"_modes",void 0),t([gt()],yt.prototype,"_actions",void 0),t([gt()],yt.prototype,"_loading",void 0),t([gt()],yt.prototype,"_error",void 0),yt=t([ct("abode-modes-tab")],yt);let vt=class extends nt{constructor(){super(...arguments),this.action=null,this._name="",this._modes=[],this._delaySeconds=0,this._selectedSensors=[],this._selectedAlarms=[],this._sensors=null,this._alarms=[],this._errors={},this._saving=!1,this._loading=!0}async connectedCallback(){super.connectedCallback(),await this._loadEntities(),this.action&&this._populateForm()}async _loadEntities(){this._loading=!0;try{const[t,e]=await Promise.all([mt(this.hass),bt(this.hass)]);this._sensors=t??null,this._alarms=e??[]}catch(t){console.error("Failed to load entities:",t)}finally{this._loading=!1}}_populateForm(){this.action&&(this._name=this.action.name,this._modes=[...this.action.modes],this._delaySeconds=this.action.delay_seconds,this._selectedSensors=[...this.action.sensor_entity_ids],this._selectedAlarms=[...this.action.alarm_entity_ids])}_toggleMode(t){this._modes.includes(t)?this._modes=this._modes.filter(e=>e!==t):this._modes=[...this._modes,t],this._clearError("modes")}_toggleSensor(t){this._selectedSensors.includes(t)?this._selectedSensors=this._selectedSensors.filter(e=>e!==t):this._selectedSensors=[...this._selectedSensors,t],this._clearError("sensors")}_toggleAlarm(t){this._selectedAlarms.includes(t)?this._selectedAlarms=this._selectedAlarms.filter(e=>e!==t):this._selectedAlarms=[...this._selectedAlarms,t],this._clearError("alarms")}_isCategorySelected(t){if(!this._sensors)return!1;const e=this._sensors[t]||[];return 0!==e.length&&e.every(t=>this._selectedSensors.includes(t.entity_id))}_isCategoryPartial(t){if(!this._sensors)return!1;const e=this._sensors[t]||[];if(0===e.length)return!1;const i=e.filter(t=>this._selectedSensors.includes(t.entity_id));return i.length>0&&i.length<e.length}_toggleCategory(t){if(!this._sensors)return;const e=(this._sensors[t]||[]).map(t=>t.entity_id);if(this._isCategorySelected(t))this._selectedSensors=this._selectedSensors.filter(t=>!e.includes(t));else{const t=e.filter(t=>!this._selectedSensors.includes(t));this._selectedSensors=[...this._selectedSensors,...t]}this._clearError("sensors")}_clearError(t){if(this._errors[t]){const{[t]:e,...i}=this._errors;this._errors=i}}_validate(){return this._errors={},this._name.trim()||(this._errors={...this._errors,name:"Name is required"}),0===this._modes.length&&(this._errors={...this._errors,modes:"Select at least one mode"}),0===this._selectedSensors.length&&(this._errors={...this._errors,sensors:"Select at least one sensor"}),0===this._selectedAlarms.length&&(this._errors={...this._errors,alarms:"Select at least one alarm"}),0===Object.keys(this._errors).length}async _handleSave(){if(this._validate()){this._saving=!0;try{const t={name:this._name.trim(),modes:this._modes,delay_seconds:this._delaySeconds,sensor_entity_ids:this._selectedSensors,alarm_entity_ids:this._selectedAlarms};this.action?await ft(this.hass,this.action.id,t):await async function(t,e){return(await t.callWS({type:"abode_security/actions/create",...e})).action}(this.hass,t),this.dispatchEvent(new CustomEvent("save"))}catch(t){console.error("Failed to save action:",t),this._errors={...this._errors,form:t instanceof Error?t.message:"Failed to save"}}finally{this._saving=!1}}}_handleCancel(){this.dispatchEvent(new CustomEvent("cancel"))}_handleOverlayClick(t){t.target===t.currentTarget&&this._handleCancel()}_handleKeydown(t){"Escape"===t.key&&this._handleCancel()}render(){return q`
+  `,t([pt({attribute:!1})],yt.prototype,"hass",void 0),t([ut()],yt.prototype,"_modes",void 0),t([ut()],yt.prototype,"_actions",void 0),t([ut()],yt.prototype,"_loading",void 0),t([ut()],yt.prototype,"_error",void 0),yt=t([ct("abode-modes-tab")],yt);const vt=2;let xt=class{constructor(t){}get _$AU(){return this._$AM._$AU}_$AT(t,e,o){this._$Ct=t,this._$AM=e,this._$Ci=o}_$AS(t,e){return this.update(t,e)}update(t,e){return this.render(...e)}};const{I:$t}=st,At=t=>t,wt=()=>document.createComment(""),St=(t,e,o)=>{const i=t._$AA.parentNode,s=void 0===e?t._$AB:e._$AA;if(void 0===o){const e=i.insertBefore(wt(),s),r=i.insertBefore(wt(),s);o=new $t(e,r,t,t.options)}else{const e=o._$AB.nextSibling,r=o._$AM,a=r!==t;if(a){let e;o._$AQ?.(t),o._$AM=t,void 0!==o._$AP&&(e=t._$AU)!==r._$AU&&o._$AP(e)}if(e!==s||a){let t=o._$AA;for(;t!==e;){const e=At(t).nextSibling;At(i).insertBefore(t,s),t=e}}}return o},Et=(t,e,o=t)=>(t._$AI(e,o),t),kt={},Ct=(t,e=kt)=>t._$AH=e,Tt=t=>{t._$AR(),t._$AA.remove()},Pt=(t,e,o)=>{const i=new Map;for(let s=e;s<=o;s++)i.set(t[s],s);return i},zt=(t=>(...e)=>({_$litDirective$:t,values:e}))(class extends xt{constructor(t){if(super(t),t.type!==vt)throw Error("repeat() can only be used in text expressions")}dt(t,e,o){let i;void 0===o?o=e:void 0!==e&&(i=e);const s=[],r=[];let a=0;for(const e of t)s[a]=i?i(e,a):a,r[a]=o(e,a),a++;return{values:r,keys:s}}render(t,e,o){return this.dt(t,e,o).values}update(t,[e,o,i]){const s=(t=>t._$AH)(t),{values:r,keys:a}=this.dt(e,o,i);if(!Array.isArray(s))return this.ut=a,r;const n=this.ut??=[],l=[];let c,d,h=0,p=s.length-1,u=0,g=r.length-1;for(;h<=p&&u<=g;)if(null===s[h])h++;else if(null===s[p])p--;else if(n[h]===a[u])l[u]=Et(s[h],r[u]),h++,u++;else if(n[p]===a[g])l[g]=Et(s[p],r[g]),p--,g--;else if(n[h]===a[g])l[g]=Et(s[h],r[g]),St(t,l[g+1],s[h]),h++,g--;else if(n[p]===a[u])l[u]=Et(s[p],r[u]),St(t,s[h],s[p]),p--,u++;else if(void 0===c&&(c=Pt(a,u,g),d=Pt(n,h,p)),c.has(n[h]))if(c.has(n[p])){const e=d.get(a[u]),o=void 0!==e?s[e]:null;if(null===o){const e=St(t,s[h]);Et(e,r[u]),l[u]=e}else l[u]=Et(o,r[u]),St(t,s[h],o),s[e]=null;u++}else Tt(s[p]),p--;else Tt(s[h]),h++;for(;u<=g;){const e=St(t,l[g+1]);Et(e,r[u]),l[u++]=e}for(;h<=p;){const t=s[h++];null!==t&&Tt(t)}return this.ut=a,Ct(t,l),q}});let Ot=0,Mt=class extends nt{constructor(){super(...arguments),this.heading="",this.variant="dialog",this.size="sm",this.dismissOnOverlay=!0,this.dismissOnEscape=!0,this._hasFooterContent=!1,this._headingId="abode-modal-heading-"+ ++Ot,this._onOverlayClick=t=>{this.dismissOnOverlay&&t.target===t.currentTarget&&this._dismiss()},this._onKeydown=t=>{this.dismissOnEscape&&"Escape"===t.key&&this._dismiss()},this._onFooterSlotChange=t=>{const e=t.target;this._hasFooterContent=e.assignedElements().length>0}}_dismiss(){this.dispatchEvent(new CustomEvent("dismiss",{bubbles:!0,composed:!0}))}render(){return L`
       <div
-        class="editor-overlay"
-        @click=${this._handleOverlayClick}
-        @keydown=${this._handleKeydown}
+        class="modal-overlay"
+        @click=${this._onOverlayClick}
+        @keydown=${this._onKeydown}
       >
-        <div class="editor-dialog" role="dialog" aria-modal="true" aria-labelledby="editor-title">
-          <h2 id="editor-title">${this.action?"Edit Action":"New Action"}</h2>
-
-          ${this._loading?q`<div class="loading">Loading...</div>`:this._renderForm()}
+        <div
+          class="modal-box"
+          role=${this.variant}
+          aria-modal="true"
+          aria-labelledby=${this._headingId}
+          data-size=${this.size}
+        >
+          <h2 id=${this._headingId}>${this.heading}</h2>
+          <slot></slot>
+          <div class="modal-footer" ?hidden=${!this._hasFooterContent}>
+            <slot name="footer" @slotchange=${this._onFooterSlotChange}></slot>
+          </div>
         </div>
       </div>
-    `}_renderForm(){return q`
+    `}};Mt.styles=a`
+    :host {
+      display: block;
+    }
+
+    .modal-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+      padding: 16px;
+    }
+
+    .modal-box {
+      background: var(--card-background-color, #fff);
+      border-radius: 8px;
+      padding: 24px;
+      width: 100%;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    }
+
+    .modal-box[data-size='sm'] {
+      max-width: 400px;
+    }
+
+    .modal-box[data-size='lg'] {
+      max-width: 600px;
+      max-height: 90vh;
+      overflow-y: auto;
+      border-radius: 12px;
+    }
+
+    h2 {
+      margin: 0 0 16px 0;
+      font-weight: 500;
+      color: var(--primary-text-color);
+    }
+
+    .modal-box[data-size='sm'] h2 {
+      font-size: 18px;
+    }
+
+    .modal-box[data-size='lg'] h2 {
+      font-size: 20px;
+      margin-bottom: 24px;
+    }
+
+    .modal-footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      margin-top: 24px;
+    }
+
+    .modal-box[data-size='lg'] .modal-footer {
+      padding-top: 16px;
+      border-top: 1px solid var(--divider-color, #e0e0e0);
+    }
+
+    ::slotted(p) {
+      margin: 0 0 24px 0;
+      color: var(--secondary-text-color);
+      line-height: 1.5;
+    }
+  `,t([pt({type:String})],Mt.prototype,"heading",void 0),t([pt({type:String})],Mt.prototype,"variant",void 0),t([pt({type:String})],Mt.prototype,"size",void 0),t([pt({type:Boolean,attribute:"dismiss-on-overlay"})],Mt.prototype,"dismissOnOverlay",void 0),t([pt({type:Boolean,attribute:"dismiss-on-escape"})],Mt.prototype,"dismissOnEscape",void 0),t([ut()],Mt.prototype,"_hasFooterContent",void 0),Mt=t([ct("abode-modal")],Mt);let Ut=class extends nt{constructor(){super(...arguments),this.action=null,this._name="",this._modes=[],this._delaySeconds=0,this._selectedSensors=[],this._selectedAlarms=[],this._sensors=null,this._alarms=[],this._errors={},this._saving=!1,this._loading=!0}async connectedCallback(){super.connectedCallback(),await this._loadEntities(),this.action&&this._populateForm()}async _loadEntities(){this._loading=!0;try{const[t,e]=await Promise.all([_t(this.hass),bt(this.hass)]);this._sensors=t??null,this._alarms=e??[]}catch(t){console.error("Failed to load entities:",t)}finally{this._loading=!1}}_populateForm(){this.action&&(this._name=this.action.name,this._modes=[...this.action.modes],this._delaySeconds=this.action.delay_seconds,this._selectedSensors=[...this.action.sensor_entity_ids],this._selectedAlarms=[...this.action.alarm_entity_ids])}_toggleMode(t){this._modes.includes(t)?this._modes=this._modes.filter(e=>e!==t):this._modes=[...this._modes,t],this._clearError("modes")}_toggleSensor(t){this._selectedSensors.includes(t)?this._selectedSensors=this._selectedSensors.filter(e=>e!==t):this._selectedSensors=[...this._selectedSensors,t],this._clearError("sensors")}_toggleAlarm(t){this._selectedAlarms.includes(t)?this._selectedAlarms=this._selectedAlarms.filter(e=>e!==t):this._selectedAlarms=[...this._selectedAlarms,t],this._clearError("alarms")}_isCategorySelected(t){if(!this._sensors)return!1;const e=this._sensors[t]||[];return 0!==e.length&&e.every(t=>this._selectedSensors.includes(t.entity_id))}_isCategoryPartial(t){if(!this._sensors)return!1;const e=this._sensors[t]||[];if(0===e.length)return!1;const o=e.filter(t=>this._selectedSensors.includes(t.entity_id));return o.length>0&&o.length<e.length}_toggleCategory(t){if(!this._sensors)return;const e=(this._sensors[t]||[]).map(t=>t.entity_id);if(this._isCategorySelected(t))this._selectedSensors=this._selectedSensors.filter(t=>!e.includes(t));else{const t=e.filter(t=>!this._selectedSensors.includes(t));this._selectedSensors=[...this._selectedSensors,...t]}this._clearError("sensors")}_clearError(t){if(this._errors[t]){const{[t]:e,...o}=this._errors;this._errors=o}}_validate(){return this._errors={},this._name.trim()||(this._errors={...this._errors,name:"Name is required"}),0===this._modes.length&&(this._errors={...this._errors,modes:"Select at least one mode"}),0===this._selectedSensors.length&&(this._errors={...this._errors,sensors:"Select at least one sensor"}),0===this._selectedAlarms.length&&(this._errors={...this._errors,alarms:"Select at least one alarm"}),0===Object.keys(this._errors).length}async _handleSave(){if(this._validate()){this._saving=!0;try{const t={name:this._name.trim(),modes:this._modes,delay_seconds:this._delaySeconds,sensor_entity_ids:this._selectedSensors,alarm_entity_ids:this._selectedAlarms};this.action?await ft(this.hass,this.action.id,t):await async function(t,e){return t.callWS({type:"abode_security/actions/create",...e})}(this.hass,t),this.dispatchEvent(new CustomEvent("save"))}catch(t){console.error("Failed to save action:",t),this._errors={...this._errors,form:t instanceof Error?t.message:"Failed to save"}}finally{this._saving=!1}}}_handleCancel(){this.dispatchEvent(new CustomEvent("cancel"))}render(){return L`
+      <abode-modal
+        heading=${this.action?"Edit Action":"New Action"}
+        size="lg"
+        @dismiss=${this._handleCancel}
+      >
+        ${this._loading?L`<div class="loading">Loading...</div>`:this._renderFormBody()}
+        ${this._loading?"":this._renderFooter()}
+      </abode-modal>
+    `}_renderFormBody(){return L`
       <div class="form-group">
         <label for="action-name">Name</label>
         <input
@@ -173,13 +260,13 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
           class=${this._errors.name?"error":""}
           placeholder="Enter action name"
         />
-        ${this._errors.name?q`<span class="error-text">${this._errors.name}</span>`:""}
+        ${this._errors.name?L`<span class="error-text">${this._errors.name}</span>`:""}
       </div>
 
       <div class="form-group">
         <label>Modes (at least one required)</label>
         <div class="checkbox-group">
-          ${["standby","home","away"].map(t=>q`
+          ${["standby","home","away"].map(t=>L`
               <label>
                 <input
                   type="checkbox"
@@ -190,7 +277,7 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
               </label>
             `)}
         </div>
-        ${this._errors.modes?q`<span class="error-text">${this._errors.modes}</span>`:""}
+        ${this._errors.modes?L`<span class="error-text">${this._errors.modes}</span>`:""}
       </div>
 
       <div class="form-group">
@@ -210,41 +297,46 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
       <div class="form-group">
         <label>Sensors (at least one required)</label>
         ${this._renderSensorSelection()}
-        ${this._errors.sensors?q`<span class="error-text">${this._errors.sensors}</span>`:""}
+        ${this._errors.sensors?L`<span class="error-text">${this._errors.sensors}</span>`:""}
       </div>
 
       <div class="form-group">
         <label>Alarms to trigger (at least one required)</label>
         ${this._renderAlarmSelection()}
-        ${this._errors.alarms?q`<span class="error-text">${this._errors.alarms}</span>`:""}
+        ${this._errors.alarms?L`<span class="error-text">${this._errors.alarms}</span>`:""}
       </div>
 
-      ${this._errors.form?q`<div class="error-text" style="margin-bottom: 16px;">
+      ${this._errors.form?L`<div class="error-text" style="margin-bottom: 16px;">
             ${this._errors.form}
           </div>`:""}
-
-      <div class="button-row">
-        <button class="cancel" @click=${this._handleCancel}>Cancel</button>
-        <button class="primary" @click=${this._handleSave} ?disabled=${this._saving}>
-          ${this._saving?"Saving...":"Save"}
-        </button>
-      </div>
-    `}_renderSensorSelection(){if(!this._sensors)return q`<div class="loading">Loading sensors...</div>`;const t=["door","window","motion","moisture","smoke","connectivity","other"].filter(t=>(this._sensors[t]||[]).length>0);return 0===t.length?q`<div class="loading">No sensors available</div>`:q`
+    `}_renderFooter(){return L`
+      <button slot="footer" class="cancel" @click=${this._handleCancel}>
+        Cancel
+      </button>
+      <button
+        slot="footer"
+        class="primary"
+        @click=${this._handleSave}
+        ?disabled=${this._saving}
+      >
+        ${this._saving?"Saving...":"Save"}
+      </button>
+    `}_renderSensorSelection(){const t=this._sensors;if(!t)return L`<div class="loading">Loading sensors...</div>`;const e=Object.keys(t).filter(e=>(t[e]??[]).length>0).sort();return 0===e.length?L`<div class="loading">No sensors available</div>`:L`
       <div class="sensor-categories">
-        ${t.map(t=>{const e=this._sensors[t]||[];return q`
+        ${e.map(e=>{const o=t[e]??[];return L`
             <div class="category">
-              <div class="category-header" @click=${()=>this._toggleCategory(t)}>
+              <div class="category-header" @click=${()=>this._toggleCategory(e)}>
                 <input
                   type="checkbox"
-                  .checked=${this._isCategorySelected(t)}
-                  .indeterminate=${this._isCategoryPartial(t)}
+                  .checked=${this._isCategorySelected(e)}
+                  .indeterminate=${this._isCategoryPartial(e)}
                   @click=${t=>t.stopPropagation()}
-                  @change=${()=>this._toggleCategory(t)}
+                  @change=${()=>this._toggleCategory(e)}
                 />
-                <span>${t} (${e.length})</span>
+                <span>${e.replace(/_/g," ")} (${o.length})</span>
               </div>
               <div class="category-items">
-                ${e.map(t=>q`
+                ${o.map(t=>L`
                     <label>
                       <input
                         type="checkbox"
@@ -258,9 +350,9 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
             </div>
           `})}
       </div>
-    `}_renderAlarmSelection(){return 0===this._alarms.length?q`<div class="loading">No alarms available</div>`:q`
+    `}_renderAlarmSelection(){return 0===this._alarms.length?L`<div class="loading">No alarms available</div>`:L`
       <div class="alarm-list">
-        ${this._alarms.map(t=>q`
+        ${this._alarms.map(t=>L`
             <label>
               <input
                 type="checkbox"
@@ -271,41 +363,9 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
             </label>
           `)}
       </div>
-    `}};vt.styles=a`
+    `}};Ut.styles=a`
     :host {
       display: block;
-    }
-
-    .editor-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgba(0, 0, 0, 0.5);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 1000;
-      padding: 16px;
-    }
-
-    .editor-dialog {
-      background: var(--card-background-color, #fff);
-      border-radius: 12px;
-      padding: 24px;
-      max-width: 600px;
-      width: 100%;
-      max-height: 90vh;
-      overflow-y: auto;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-    }
-
-    h2 {
-      margin: 0 0 24px 0;
-      font-size: 20px;
-      font-weight: 500;
-      color: var(--primary-text-color);
     }
 
     .form-group {
@@ -472,16 +532,10 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
       accent-color: var(--primary-color, #03a9f4);
     }
 
-    .button-row {
-      display: flex;
-      justify-content: flex-end;
-      gap: 8px;
-      margin-top: 24px;
-      padding-top: 16px;
-      border-top: 1px solid var(--divider-color, #e0e0e0);
-    }
-
-    .button-row button {
+    /* Footer button styles — applied to <button slot="footer"> inside <abode-modal>.
+     * The selector intentionally matches all slot="footer" buttons in this
+     * shadow root, which today only exist inside <abode-modal>. */
+    button[slot='footer'] {
       padding: 10px 20px;
       border: none;
       border-radius: 4px;
@@ -491,30 +545,30 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
       transition: background 0.2s;
     }
 
-    .button-row button.cancel {
+    button[slot='footer'].cancel {
       background: transparent;
       color: var(--secondary-text-color);
     }
 
-    .button-row button.cancel:hover {
+    button[slot='footer'].cancel:hover {
       background: var(--secondary-background-color);
     }
 
-    .button-row button.primary {
+    button[slot='footer'].primary {
       background: var(--primary-color, #03a9f4);
       color: white;
     }
 
-    .button-row button.primary:hover:not(:disabled) {
+    button[slot='footer'].primary:hover:not(:disabled) {
       background: var(--primary-color-dark, #0288d1);
     }
 
-    .button-row button.primary:disabled {
+    button[slot='footer'].primary:disabled {
       opacity: 0.5;
       cursor: not-allowed;
     }
 
-    .button-row button:focus-visible {
+    button[slot='footer']:focus-visible {
       outline: 2px solid var(--primary-color);
       outline-offset: 2px;
     }
@@ -524,8 +578,8 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
       padding: 24px;
       color: var(--secondary-text-color);
     }
-  `,t([pt({attribute:!1})],vt.prototype,"hass",void 0),t([pt({attribute:!1})],vt.prototype,"action",void 0),t([gt()],vt.prototype,"_name",void 0),t([gt()],vt.prototype,"_modes",void 0),t([gt()],vt.prototype,"_delaySeconds",void 0),t([gt()],vt.prototype,"_selectedSensors",void 0),t([gt()],vt.prototype,"_selectedAlarms",void 0),t([gt()],vt.prototype,"_sensors",void 0),t([gt()],vt.prototype,"_alarms",void 0),t([gt()],vt.prototype,"_errors",void 0),t([gt()],vt.prototype,"_saving",void 0),t([gt()],vt.prototype,"_loading",void 0),vt=t([ct("abode-action-editor")],vt);let xt=class extends nt{constructor(){super(...arguments),this._actions=[],this._loading=!0,this._error=null,this._editingAction=null,this._showEditor=!1,this._showDeleteConfirm=!1,this._showTestConfirm=!1,this._pendingAction=null,this._togglingIds=new Set,this._operationError=null}async connectedCallback(){super.connectedCallback(),await this._loadData()}async _loadData(){this._loading=!0,this._error=null;try{this._actions=await ut(this.hass)??[]}catch(t){this._error=t instanceof Error?t.message:"Failed to load actions"}finally{this._loading=!1}}_getRecentTriggers(){return(this._actions??[]).filter(t=>t.last_triggered).sort((t,e)=>new Date(e.last_triggered).getTime()-new Date(t.last_triggered).getTime()).slice(0,5)}_formatTime(t){if(!t)return"";const e=new Date(t),i=(new Date).getTime()-e.getTime(),o=Math.floor(i/6e4),s=Math.floor(i/36e5),r=Math.floor(i/864e5);return o<1?"Just now":o<60?`${o}m ago`:s<24?`${s}h ago`:r<7?`${r}d ago`:e.toLocaleDateString()}_addAction(){this._editingAction=null,this._showEditor=!0}_editAction(t){this._editingAction=t,this._showEditor=!0}async _toggleAction(t){const e=t.id;this._togglingIds=new Set([...this._togglingIds,e]),this._operationError=null;try{const i=await ft(this.hass,e,{enabled:!t.enabled});this._actions=this._actions.map(t=>t.id===e?i:t)}catch(e){console.error("Failed to toggle action:",e),this._operationError=`Failed to ${t.enabled?"disable":"enable"} action`}finally{this._togglingIds=new Set([...this._togglingIds].filter(t=>t!==e))}}_requestDelete(t){this._pendingAction=t,this._showDeleteConfirm=!0}async _confirmDelete(){if(this._pendingAction){this._operationError=null;try{await async function(t,e){await t.callWS({type:"abode_security/actions/delete",action_id:e})}(this.hass,this._pendingAction.id),this._actions=this._actions.filter(t=>t.id!==this._pendingAction.id)}catch(t){console.error("Failed to delete action:",t),this._operationError="Failed to delete action"}finally{this._showDeleteConfirm=!1,this._pendingAction=null}}}_requestTest(t){this._pendingAction=t,this._showTestConfirm=!0}async _confirmTest(){if(this._pendingAction){this._operationError=null;try{await async function(t,e){await t.callWS({type:"abode_security/actions/test",action_id:e})}(this.hass,this._pendingAction.id)}catch(t){console.error("Failed to test action:",t),this._operationError="Failed to test action"}finally{this._showTestConfirm=!1,this._pendingAction=null}}}_closeEditor(){this._showEditor=!1,this._editingAction=null}async _handleSave(){this._closeEditor(),await this._loadData()}render(){if(this._loading)return q`<div class="loading">Loading actions...</div>`;if(this._error)return q`<div class="error" role="alert">${this._error}</div>`;const t=this._getRecentTriggers();return q`
-      ${this._operationError?q`
+  `,t([pt({attribute:!1})],Ut.prototype,"hass",void 0),t([pt({attribute:!1})],Ut.prototype,"action",void 0),t([ut()],Ut.prototype,"_name",void 0),t([ut()],Ut.prototype,"_modes",void 0),t([ut()],Ut.prototype,"_delaySeconds",void 0),t([ut()],Ut.prototype,"_selectedSensors",void 0),t([ut()],Ut.prototype,"_selectedAlarms",void 0),t([ut()],Ut.prototype,"_sensors",void 0),t([ut()],Ut.prototype,"_alarms",void 0),t([ut()],Ut.prototype,"_errors",void 0),t([ut()],Ut.prototype,"_saving",void 0),t([ut()],Ut.prototype,"_loading",void 0),Ut=t([ct("abode-action-editor")],Ut);let Dt=class extends nt{constructor(){super(...arguments),this._actions=[],this._loading=!0,this._error=null,this._editingAction=null,this._showEditor=!1,this._confirm=null,this._togglingIds=new Set,this._operationError=null}async connectedCallback(){super.connectedCallback(),await this._loadData()}async _loadData(){this._loading=!0,this._error=null;try{this._actions=await gt(this.hass)??[]}catch(t){this._error=t instanceof Error?t.message:"Failed to load actions"}finally{this._loading=!1}}_getRecentTriggers(){return(this._actions??[]).filter(t=>t.last_triggered).sort((t,e)=>new Date(e.last_triggered).getTime()-new Date(t.last_triggered).getTime()).slice(0,5)}_formatTime(t){if(!t)return"";const e=new Date(t),o=(new Date).getTime()-e.getTime(),i=Math.floor(o/6e4),s=Math.floor(o/36e5),r=Math.floor(o/864e5);return i<1?"Just now":i<60?`${i}m ago`:s<24?`${s}h ago`:r<7?`${r}d ago`:e.toLocaleDateString()}_addAction(){this._editingAction=null,this._showEditor=!0}_editAction(t){this._editingAction=t,this._showEditor=!0}async _toggleAction(t){const e=t.id;this._togglingIds=new Set([...this._togglingIds,e]),this._operationError=null;try{const o=await ft(this.hass,e,{enabled:!t.enabled});this._actions=this._actions.map(t=>t.id===e?o:t)}catch(e){console.error("Failed to toggle action:",e),this._operationError=`Failed to ${t.enabled?"disable":"enable"} action`}finally{this._togglingIds=new Set([...this._togglingIds].filter(t=>t!==e))}}_requestDelete(t){this._confirm={kind:"delete",action:t}}async _confirmDelete(){if("delete"!==this._confirm?.kind)return;const{action:t}=this._confirm;this._confirm=null,this._operationError=null;try{await async function(t,e){await t.callWS({type:"abode_security/actions/delete",action_id:e})}(this.hass,t.id),this._actions=this._actions.filter(e=>e.id!==t.id)}catch(t){console.error("Failed to delete action:",t),this._operationError="Failed to delete action"}}_requestTest(t){this._confirm={kind:"test",action:t}}async _confirmTest(){if("test"!==this._confirm?.kind)return;const{action:t}=this._confirm;this._confirm=null,this._operationError=null;try{await async function(t,e){await t.callWS({type:"abode_security/actions/test",action_id:e})}(this.hass,t.id)}catch(t){console.error("Failed to test action:",t),this._operationError="Failed to test action"}}_closeEditor(){this._showEditor=!1,this._editingAction=null}async _handleSave(){this._closeEditor(),await this._loadData()}render(){if(this._loading)return L`<div class="loading">Loading actions...</div>`;if(this._error)return L`<div class="error" role="alert">${this._error}</div>`;const t=this._getRecentTriggers();return L`
+      ${this._operationError?L`
             <div class="operation-error" role="alert">
               ${this._operationError}
               <button
@@ -549,7 +603,7 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
         </button>
       </div>
 
-      ${0===this._actions.length?q`
+      ${0===this._actions.length?L`
             <div class="empty-state">
               <ha-icon icon="mdi:bell-off-outline"></ha-icon>
               <p>No actions configured</p>
@@ -558,19 +612,19 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
                 Create your first action
               </button>
             </div>
-          `:q`
+          `:L`
             <div class="actions-list" role="list">
-              ${this._actions.map(t=>this._renderActionRow(t))}
+              ${zt(this._actions,t=>t.id,t=>this._renderActionRow(t))}
             </div>
           `}
 
       <div class="recent-triggers">
         <h3>Recent Triggers</h3>
-        ${0===t.length?q`<div class="empty-state" style="padding: 24px;">
+        ${0===t.length?L`<div class="empty-state" style="padding: 24px;">
               No recent triggers
-            </div>`:q`
+            </div>`:L`
               <div class="trigger-list">
-                ${t.map(t=>q`
+                ${t.map(t=>L`
                     <div class="trigger-item">
                       <span class="trigger-name">${t.name}</span>
                       <span class="trigger-time"
@@ -582,7 +636,7 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
             `}
       </div>
 
-      ${this._showEditor?q`
+      ${this._showEditor?L`
             <abode-action-editor
               .hass=${this.hass}
               .action=${this._editingAction}
@@ -590,17 +644,17 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
               @cancel=${this._closeEditor}
             ></abode-action-editor>
           `:""}
-      ${this._showDeleteConfirm?this._renderDeleteDialog():""}
-      ${this._showTestConfirm?this._renderTestDialog():""}
-    `}_renderActionRow(t){const e=this._togglingIds.has(t.id);return q`
+      ${"delete"===this._confirm?.kind?this._renderDeleteDialog():""}
+      ${"test"===this._confirm?.kind?this._renderTestDialog():""}
+    `}_renderActionRow(t){const e=this._togglingIds.has(t.id);return L`
       <div class="action-row ${t.enabled?"":"disabled"}" role="listitem">
         <div class="action-info">
           <div class="action-name">${t.name}</div>
           <div class="action-meta">
             <div class="modes-list">
-              ${t.modes.map(t=>q`<span class="mode-chip">${t}</span>`)}
+              ${t.modes.map(t=>L`<span class="mode-chip">${t}</span>`)}
             </div>
-            ${t.trigger_count>0?q`<span class="trigger-info"
+            ${t.trigger_count>0?L`<span class="trigger-info"
                   >${t.trigger_count} triggers</span
                 >`:""}
           </div>
@@ -642,56 +696,56 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
           </button>
         </div>
       </div>
-    `}_renderDeleteDialog(){return q`
-      <div
-        class="dialog-overlay"
-        @click=${t=>{t.target===t.currentTarget&&(this._showDeleteConfirm=!1)}}
-        @keydown=${t=>{"Escape"===t.key&&(this._showDeleteConfirm=!1)}}
+    `}_renderDeleteDialog(){return L`
+      <abode-modal
+        heading="Delete Action"
+        variant="alertdialog"
+        @dismiss=${()=>this._confirm=null}
       >
-        <div class="dialog" role="alertdialog" aria-modal="true" aria-labelledby="delete-title">
-          <h3 id="delete-title">Delete Action</h3>
-          <p>
-            Delete action "${this._pendingAction?.name}"? This cannot be undone.
-          </p>
-          <div class="dialog-actions">
-            <button
-              class="dialog-button cancel"
-              @click=${()=>this._showDeleteConfirm=!1}
-            >
-              Cancel
-            </button>
-            <button class="dialog-button danger" @click=${this._confirmDelete}>
-              Delete
-            </button>
-          </div>
-        </div>
-      </div>
-    `}_renderTestDialog(){return q`
-      <div
-        class="dialog-overlay"
-        @click=${t=>{t.target===t.currentTarget&&(this._showTestConfirm=!1)}}
-        @keydown=${t=>{"Escape"===t.key&&(this._showTestConfirm=!1)}}
+        <p>
+          Delete action "${this._confirm?.action.name}"? This cannot be undone.
+        </p>
+        <button
+          slot="footer"
+          class="dialog-button cancel"
+          @click=${()=>this._confirm=null}
+        >
+          Cancel
+        </button>
+        <button
+          slot="footer"
+          class="dialog-button danger"
+          @click=${this._confirmDelete}
+        >
+          Delete
+        </button>
+      </abode-modal>
+    `}_renderTestDialog(){return L`
+      <abode-modal
+        heading="Test Action"
+        variant="alertdialog"
+        @dismiss=${()=>this._confirm=null}
       >
-        <div class="dialog" role="alertdialog" aria-modal="true" aria-labelledby="test-title">
-          <h3 id="test-title">Test Action</h3>
-          <p>
-            This will trigger real alarms. Are you sure you want to test
-            "${this._pendingAction?.name}"?
-          </p>
-          <div class="dialog-actions">
-            <button
-              class="dialog-button cancel"
-              @click=${()=>this._showTestConfirm=!1}
-            >
-              Cancel
-            </button>
-            <button class="dialog-button primary" @click=${this._confirmTest}>
-              Test
-            </button>
-          </div>
-        </div>
-      </div>
-    `}};xt.styles=a`
+        <p>
+          This will trigger real alarms. Are you sure you want to test
+          "${this._confirm?.action.name}"?
+        </p>
+        <button
+          slot="footer"
+          class="dialog-button cancel"
+          @click=${()=>this._confirm=null}
+        >
+          Cancel
+        </button>
+        <button
+          slot="footer"
+          class="dialog-button primary"
+          @click=${this._confirmTest}
+        >
+          Test
+        </button>
+      </abode-modal>
+    `}};Dt.styles=a`
     :host {
       display: block;
     }
@@ -922,48 +976,7 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
       opacity: 1;
     }
 
-    /* Dialog styles */
-    .dialog-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgba(0, 0, 0, 0.5);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 1000;
-    }
-
-    .dialog {
-      background: var(--card-background-color, #fff);
-      border-radius: 8px;
-      padding: 24px;
-      max-width: 400px;
-      width: 90%;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-    }
-
-    .dialog h3 {
-      margin: 0 0 16px 0;
-      font-size: 18px;
-      font-weight: 500;
-      color: var(--primary-text-color);
-    }
-
-    .dialog p {
-      margin: 0 0 24px 0;
-      color: var(--secondary-text-color);
-      line-height: 1.5;
-    }
-
-    .dialog-actions {
-      display: flex;
-      justify-content: flex-end;
-      gap: 8px;
-    }
-
+    /* Dialog button styles — applied to <button slot="footer"> inside <abode-modal>. */
     .dialog-button {
       padding: 8px 16px;
       border: none;
@@ -1055,7 +1068,7 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
       outline: 2px solid var(--primary-color);
       outline-offset: 2px;
     }
-  `,t([pt({attribute:!1})],xt.prototype,"hass",void 0),t([gt()],xt.prototype,"_actions",void 0),t([gt()],xt.prototype,"_loading",void 0),t([gt()],xt.prototype,"_error",void 0),t([gt()],xt.prototype,"_editingAction",void 0),t([gt()],xt.prototype,"_showEditor",void 0),t([gt()],xt.prototype,"_showDeleteConfirm",void 0),t([gt()],xt.prototype,"_showTestConfirm",void 0),t([gt()],xt.prototype,"_pendingAction",void 0),t([gt()],xt.prototype,"_togglingIds",void 0),t([gt()],xt.prototype,"_operationError",void 0),xt=t([ct("abode-actions-tab")],xt);let $t=class extends nt{constructor(){super(...arguments),this._activeTab="actions",this._activeTabId="actions-panel"}updated(t){super.updated(t),t.has("_activeTab")&&(this._activeTabId="modes"===this._activeTab?"modes-panel":"actions-panel")}render(){return q`
+  `,t([pt({attribute:!1})],Dt.prototype,"hass",void 0),t([ut()],Dt.prototype,"_actions",void 0),t([ut()],Dt.prototype,"_loading",void 0),t([ut()],Dt.prototype,"_error",void 0),t([ut()],Dt.prototype,"_editingAction",void 0),t([ut()],Dt.prototype,"_showEditor",void 0),t([ut()],Dt.prototype,"_confirm",void 0),t([ut()],Dt.prototype,"_togglingIds",void 0),t([ut()],Dt.prototype,"_operationError",void 0),Dt=t([ct("abode-actions-tab")],Dt);let Nt=class extends nt{constructor(){super(...arguments),this._activeTab="actions"}render(){const t="modes"===this._activeTab?"modes-panel":"actions-panel";return L`
       <div class="panel-content">
         <div class="header">
           <h1>Abode Configuration</h1>
@@ -1087,13 +1100,13 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
         <div
           class="tab-content"
           role="tabpanel"
-          id=${this._activeTabId}
+          id=${t}
           aria-labelledby=${"modes"===this._activeTab?"modes-tab":"actions-tab"}
         >
-          ${"modes"===this._activeTab?q`<abode-modes-tab .hass=${this.hass}></abode-modes-tab>`:q`<abode-actions-tab .hass=${this.hass}></abode-actions-tab>`}
+          ${"modes"===this._activeTab?L`<abode-modes-tab .hass=${this.hass}></abode-modes-tab>`:L`<abode-actions-tab .hass=${this.hass}></abode-actions-tab>`}
         </div>
       </div>
-    `}};$t.styles=a`
+    `}};Nt.styles=a`
     :host {
       display: block;
       background-color: var(--primary-background-color);
@@ -1162,4 +1175,4 @@ function t(t,e,i,o){var s,r=arguments.length,a=r<3?e:null===o?o=Object.getOwnPro
     .tab-content {
       min-height: 400px;
     }
-  `,t([pt({attribute:!1})],$t.prototype,"hass",void 0),t([gt()],$t.prototype,"_activeTab",void 0),t([gt()],$t.prototype,"_activeTabId",void 0),$t=t([ct("abode-configuration-panel")],$t);export{$t as AbodeConfigurationPanel};
+  `,t([pt({attribute:!1})],Nt.prototype,"hass",void 0),t([ut()],Nt.prototype,"_activeTab",void 0),Nt=t([ct("abode-configuration-panel")],Nt);export{Nt as AbodeConfigurationPanel};

--- a/frontend/src/__tests__/abode-modal.test.ts
+++ b/frontend/src/__tests__/abode-modal.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for the <abode-modal> component.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '../abode-modal.js';
+import type { AbodeModal } from '../abode-modal.js';
+import { elementUpdated } from './test-helpers.js';
+
+describe('AbodeModal', () => {
+  describe('rendering', () => {
+    it('renders the heading prop', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Delete Action"></abode-modal>
+      `);
+      await elementUpdated(el);
+
+      expect(el.shadowRoot?.textContent).to.include('Delete Action');
+    });
+
+    it('projects default slot content into the body', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading">
+          <p data-testid="body">Body paragraph</p>
+        </abode-modal>
+      `);
+      await elementUpdated(el);
+
+      // Verify projection actually happens: the shadow's default <slot> must
+      // have the light-DOM <p> as an assigned element. Asserting only that
+      // the light-DOM child exists wouldn't catch a missing shadow <slot>.
+      const defaultSlot = el.shadowRoot?.querySelector(
+        'slot:not([name])',
+      ) as HTMLSlotElement | null;
+      expect(defaultSlot, 'default slot must be present in shadow').to.exist;
+      const assigned = defaultSlot!.assignedElements();
+      expect(assigned.length).to.equal(1);
+      expect(assigned[0].getAttribute('data-testid')).to.equal('body');
+    });
+
+    it('projects content into the footer slot', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading">
+          <p>Body</p>
+          <div slot="footer" data-testid="footer">
+            <button>Cancel</button>
+            <button>OK</button>
+          </div>
+        </abode-modal>
+      `);
+      await elementUpdated(el);
+
+      const footerSlot = el.shadowRoot?.querySelector(
+        'slot[name="footer"]',
+      ) as HTMLSlotElement | null;
+      expect(footerSlot, 'footer slot must be present in shadow').to.exist;
+      const assigned = footerSlot!.assignedElements();
+      expect(assigned.length).to.equal(1);
+      expect(assigned[0].getAttribute('data-testid')).to.equal('footer');
+      expect(assigned[0].querySelectorAll('button').length).to.equal(2);
+    });
+
+    it('hides the footer wrapper when no footer content is slotted', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading">
+          <p>Body only, no footer</p>
+        </abode-modal>
+      `);
+      await elementUpdated(el);
+
+      const footer = el.shadowRoot?.querySelector('.modal-footer') as HTMLElement | null;
+      expect(footer).to.exist;
+      // The hidden attribute is the source of truth here; some browsers also
+      // reflect display:none, but we only need to verify the attribute toggle.
+      expect(footer!.hasAttribute('hidden')).to.equal(true);
+    });
+
+    it('shows the footer wrapper when footer content is slotted', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading">
+          <p>Body</p>
+          <button slot="footer">OK</button>
+        </abode-modal>
+      `);
+      await elementUpdated(el);
+
+      const footer = el.shadowRoot?.querySelector('.modal-footer') as HTMLElement | null;
+      expect(footer).to.exist;
+      expect(footer!.hasAttribute('hidden')).to.equal(false);
+    });
+  });
+
+  describe('aria attributes', () => {
+    it('defaults to role="dialog" and aria-modal="true"', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading"></abode-modal>
+      `);
+      await elementUpdated(el);
+
+      const box = el.shadowRoot?.querySelector('.modal-box');
+      expect(box?.getAttribute('role')).to.equal('dialog');
+      expect(box?.getAttribute('aria-modal')).to.equal('true');
+    });
+
+    it('uses role="alertdialog" when variant="alertdialog"', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading" variant="alertdialog"></abode-modal>
+      `);
+      await elementUpdated(el);
+
+      const box = el.shadowRoot?.querySelector('.modal-box');
+      expect(box?.getAttribute('role')).to.equal('alertdialog');
+    });
+
+    it('points aria-labelledby at the heading element', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading"></abode-modal>
+      `);
+      await elementUpdated(el);
+
+      const box = el.shadowRoot?.querySelector('.modal-box');
+      const labelledBy = box?.getAttribute('aria-labelledby');
+      expect(labelledBy).to.be.a('string').and.to.have.length.greaterThan(0);
+      const heading = el.shadowRoot?.getElementById(labelledBy!);
+      expect(heading?.textContent).to.equal('Heading');
+    });
+  });
+
+  describe('dismiss', () => {
+    it('dispatches dismiss when overlay clicked (target === overlay)', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading"></abode-modal>
+      `);
+      await elementUpdated(el);
+
+      let dismissed = false;
+      el.addEventListener('dismiss', () => {
+        dismissed = true;
+      });
+
+      const overlay = el.shadowRoot?.querySelector('.modal-overlay') as HTMLElement;
+      overlay?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+
+      expect(dismissed).to.equal(true);
+    });
+
+    it('does NOT dispatch dismiss when clicking inside the dialog body', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading">
+          <p data-testid="body">Body</p>
+        </abode-modal>
+      `);
+      await elementUpdated(el);
+
+      let dismissed = false;
+      el.addEventListener('dismiss', () => {
+        dismissed = true;
+      });
+
+      // Click the dialog box itself — overlay's click handler should ignore it
+      // because target !== currentTarget.
+      const box = el.shadowRoot?.querySelector('.modal-box') as HTMLElement;
+      box?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+
+      expect(dismissed).to.equal(false);
+    });
+
+    it('dispatches dismiss on Escape keydown bubbling from a descendant', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading"></abode-modal>
+      `);
+      await elementUpdated(el);
+
+      let dismissed = false;
+      el.addEventListener('dismiss', () => {
+        dismissed = true;
+      });
+
+      // Real keydown originates on a focused descendant and bubbles up to the
+      // overlay handler — dispatch from .modal-box with bubbles+composed so the
+      // test mirrors the actual browser flow rather than the listener's host.
+      const box = el.shadowRoot?.querySelector('.modal-box') as HTMLElement;
+      box?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }),
+      );
+
+      expect(dismissed).to.equal(true);
+    });
+
+    it('does not dispatch dismiss on non-Escape keys', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading"></abode-modal>
+      `);
+      await elementUpdated(el);
+
+      let dismissed = false;
+      el.addEventListener('dismiss', () => {
+        dismissed = true;
+      });
+
+      const box = el.shadowRoot?.querySelector('.modal-box') as HTMLElement;
+      box?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true }),
+      );
+      box?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'a', bubbles: true, composed: true }),
+      );
+
+      expect(dismissed).to.equal(false);
+    });
+
+    it('dismissOnOverlay=false disables overlay-click dismiss', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading" .dismissOnOverlay=${false}></abode-modal>
+      `);
+      await elementUpdated(el);
+
+      let dismissed = false;
+      el.addEventListener('dismiss', () => {
+        dismissed = true;
+      });
+
+      const overlay = el.shadowRoot?.querySelector('.modal-overlay') as HTMLElement;
+      overlay?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+
+      expect(dismissed).to.equal(false);
+    });
+
+    it('dismissOnEscape=false disables Escape dismiss', async () => {
+      const el = await fixture<AbodeModal>(html`
+        <abode-modal heading="Heading" .dismissOnEscape=${false}></abode-modal>
+      `);
+      await elementUpdated(el);
+
+      let dismissed = false;
+      el.addEventListener('dismiss', () => {
+        dismissed = true;
+      });
+
+      const box = el.shadowRoot?.querySelector('.modal-box') as HTMLElement;
+      box?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }),
+      );
+
+      expect(dismissed).to.equal(false);
+    });
+  });
+
+  describe('size variant', () => {
+    it('applies the size attribute to the modal box for styling', async () => {
+      const small = await fixture<AbodeModal>(html`
+        <abode-modal heading="S" size="sm"></abode-modal>
+      `);
+      await elementUpdated(small);
+      expect(small.shadowRoot?.querySelector('.modal-box[data-size="sm"]')).to.exist;
+
+      const large = await fixture<AbodeModal>(html`
+        <abode-modal heading="L" size="lg"></abode-modal>
+      `);
+      await elementUpdated(large);
+      expect(large.shadowRoot?.querySelector('.modal-box[data-size="lg"]')).to.exist;
+    });
+  });
+});

--- a/frontend/src/__tests__/action-editor.test.ts
+++ b/frontend/src/__tests__/action-editor.test.ts
@@ -34,7 +34,10 @@ describe('ActionEditor', () => {
       el._loading = false;
       await elementUpdated(el);
 
-      expect(el.shadowRoot?.textContent).to.include('New Action');
+      // Heading is rendered inside <abode-modal>'s shadow root, so it's not in
+      // textContent — read it off the heading attribute instead.
+      const modal = el.shadowRoot?.querySelector('abode-modal');
+      expect(modal?.getAttribute('heading')).to.equal('New Action');
     });
 
     it('renders edit form when action provided', async () => {
@@ -52,7 +55,8 @@ describe('ActionEditor', () => {
       el._loading = false;
       await elementUpdated(el);
 
-      expect(el.shadowRoot?.textContent).to.include('Edit Action');
+      const modal = el.shadowRoot?.querySelector('abode-modal');
+      expect(modal?.getAttribute('heading')).to.equal('Edit Action');
     });
 
     it('displays sensors grouped by category', async () => {
@@ -209,7 +213,7 @@ describe('ActionEditor', () => {
       expect(cancelFired).to.be.true;
     });
 
-    it('dispatches cancel event on Escape key', async () => {
+    it('dispatches cancel event when modal dispatches dismiss', async () => {
       const hass = createMockHass();
       const el = await fixture<ActionEditor>(html`
         <abode-action-editor .hass=${hass}></abode-action-editor>
@@ -228,9 +232,10 @@ describe('ActionEditor', () => {
         cancelFired = true;
       });
 
-      // Dispatch Escape key event
-      const overlay = el.shadowRoot?.querySelector('.editor-overlay') as HTMLElement;
-      overlay?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      // The modal owns Escape/overlay-click handling and emits `dismiss`;
+      // the editor responds by firing `cancel`.
+      const modal = el.shadowRoot?.querySelector('abode-modal') as HTMLElement;
+      modal?.dispatchEvent(new CustomEvent('dismiss', { bubbles: true, composed: true }));
 
       expect(cancelFired).to.be.true;
     });
@@ -257,7 +262,7 @@ describe('ActionEditor', () => {
   });
 
   describe('accessibility', () => {
-    it('editor overlay has proper ARIA attributes', async () => {
+    it('renders the editor inside <abode-modal> with the dialog variant', async () => {
       const hass = createMockHass();
       const el = await fixture<ActionEditor>(html`
         <abode-action-editor .hass=${hass}></abode-action-editor>
@@ -271,9 +276,16 @@ describe('ActionEditor', () => {
       el._loading = false;
       await elementUpdated(el);
 
-      const dialog = el.shadowRoot?.querySelector('.editor-dialog');
-      expect(dialog?.getAttribute('role')).to.equal('dialog');
-      expect(dialog?.getAttribute('aria-modal')).to.equal('true');
+      // role/aria-modal correctness is owned by <abode-modal> and covered in
+      // abode-modal.test.ts. Here we verify the editor leaves the variant at
+      // its default by not setting the attribute (no explicit `variant="..."`),
+      // which means the modal renders the standard 'dialog' role rather than
+      // the 'alertdialog' that confirms use.
+      const modal = el.shadowRoot?.querySelector('abode-modal');
+      expect(modal).to.exist;
+      expect(modal?.hasAttribute('variant')).to.equal(false);
+      // The modal's default property value is 'dialog'.
+      expect((modal as unknown as { variant?: string })?.variant).to.equal('dialog');
     });
   });
 });

--- a/frontend/src/__tests__/actions-tab.test.ts
+++ b/frontend/src/__tests__/actions-tab.test.ts
@@ -171,9 +171,11 @@ describe('ActionsTab', () => {
 
       await elementUpdated(el);
 
-      const dialog = el.shadowRoot?.querySelector('.dialog');
-      expect(dialog).to.exist;
-      expect(dialog?.textContent).to.include('Delete Action');
+      const modal = el.shadowRoot?.querySelector('abode-modal');
+      expect(modal).to.exist;
+      expect(modal?.getAttribute('heading')).to.equal('Delete Action');
+      // Body text is slotted into the modal but lives in the parent's shadow tree.
+      expect(el.shadowRoot?.textContent).to.include('cannot be undone');
     });
 
     it('shows test confirmation dialog', async () => {
@@ -195,9 +197,10 @@ describe('ActionsTab', () => {
 
       await elementUpdated(el);
 
-      const dialog = el.shadowRoot?.querySelector('.dialog');
-      expect(dialog).to.exist;
-      expect(dialog?.textContent).to.include('trigger real alarms');
+      const modal = el.shadowRoot?.querySelector('abode-modal');
+      expect(modal).to.exist;
+      expect(modal?.getAttribute('heading')).to.equal('Test Action');
+      expect(el.shadowRoot?.textContent).to.include('trigger real alarms');
     });
   });
 
@@ -280,10 +283,11 @@ describe('ActionsTab', () => {
       await elementUpdated(el);
 
       // Exactly one confirm is open, and it's the test dialog targeting a2.
-      const dialogs = el.shadowRoot?.querySelectorAll('.dialog');
-      expect(dialogs?.length).to.equal(1);
-      expect(dialogs?.[0]?.textContent).to.include('trigger real alarms');
-      expect(dialogs?.[0]?.textContent).to.include('A2');
+      const modals = el.shadowRoot?.querySelectorAll('abode-modal');
+      expect(modals?.length).to.equal(1);
+      expect(modals?.[0]?.getAttribute('heading')).to.equal('Test Action');
+      expect(el.shadowRoot?.textContent).to.include('trigger real alarms');
+      expect(el.shadowRoot?.textContent).to.include('A2');
     });
 
     it('cancelling a delete confirm clears confirm state without throwing', async () => {
@@ -310,7 +314,7 @@ describe('ActionsTab', () => {
       await elementUpdated(el);
 
       // Dialog gone, action list unchanged.
-      expect(el.shadowRoot?.querySelector('.dialog')).to.equal(null);
+      expect(el.shadowRoot?.querySelector('abode-modal')).to.equal(null);
       // @ts-expect-error - accessing private property for testing
       expect(el._confirm).to.equal(null);
       // @ts-expect-error - accessing private property for testing
@@ -423,7 +427,7 @@ describe('ActionsTab', () => {
       expect(row?.getAttribute('role')).to.equal('listitem');
     });
 
-    it('delete dialog has proper ARIA attributes', async () => {
+    it('delete dialog uses alertdialog variant', async () => {
       const hass = createMockHass();
 
       const el = await fixture<ActionsTab>(html`
@@ -441,9 +445,10 @@ describe('ActionsTab', () => {
       deleteButton?.click();
       await elementUpdated(el);
 
-      const dialog = el.shadowRoot?.querySelector('.dialog');
-      expect(dialog?.getAttribute('role')).to.equal('alertdialog');
-      expect(dialog?.getAttribute('aria-modal')).to.equal('true');
+      // <abode-modal> owns role/aria-modal — those are covered in abode-modal.test.ts.
+      // Here we just verify the action-tab passes the right variant prop.
+      const modal = el.shadowRoot?.querySelector('abode-modal');
+      expect(modal?.getAttribute('variant')).to.equal('alertdialog');
     });
   });
 });

--- a/frontend/src/abode-modal.ts
+++ b/frontend/src/abode-modal.ts
@@ -1,0 +1,172 @@
+/**
+ * <abode-modal> — shared modal dialog used by the actions tab and editor.
+ *
+ * Provides the overlay + box scaffolding, ARIA attributes, and overlay/Escape
+ * dismiss behavior. Consumers fill the body via the default slot and the
+ * footer (button row) via the `footer` slot.
+ *
+ * The internal `<h2>` gets a generated id and is wired up via `aria-labelledby`
+ * on the dialog box, so consumers only need to pass the `heading` text.
+ *
+ * Known limitation: the Escape `keydown` listener lives on the overlay div,
+ * which never receives focus on its own. Pressing Escape only works once
+ * something inside the dialog has been tab-focused. Tracked as #28; the focus
+ * move/trap/restore + document-level Escape listener will be added in the a11y
+ * follow-up (#9 + #28 group). The `dismiss` event contract here stays the
+ * same.
+ *
+ * @fires dismiss - Dispatched on overlay click (when dismissOnOverlay) or
+ *                  Escape keydown (when dismissOnEscape) — see the focus
+ *                  caveat above.
+ *
+ * @prop {string} heading                - Title text rendered above the body.
+ * @prop {'dialog' | 'alertdialog'} variant - ARIA role on the dialog box; default 'dialog'.
+ * @prop {'sm' | 'lg'} size              - 'sm' (max-width 400px) or 'lg' (max-width 600px, scrollable).
+ * @prop {boolean} dismissOnOverlay      - Default true.
+ * @prop {boolean} dismissOnEscape       - Default true.
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+let modalIdSeq = 0;
+
+@customElement('abode-modal')
+export class AbodeModal extends LitElement {
+  @property({ type: String }) heading = '';
+  @property({ type: String }) variant: 'dialog' | 'alertdialog' = 'dialog';
+  @property({ type: String }) size: 'sm' | 'lg' = 'sm';
+  @property({ type: Boolean, attribute: 'dismiss-on-overlay' }) dismissOnOverlay = true;
+  @property({ type: Boolean, attribute: 'dismiss-on-escape' }) dismissOnEscape = true;
+
+  @state() private _hasFooterContent = false;
+
+  private readonly _headingId = `abode-modal-heading-${++modalIdSeq}`;
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .modal-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+      padding: 16px;
+    }
+
+    .modal-box {
+      background: var(--card-background-color, #fff);
+      border-radius: 8px;
+      padding: 24px;
+      width: 100%;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    }
+
+    .modal-box[data-size='sm'] {
+      max-width: 400px;
+    }
+
+    .modal-box[data-size='lg'] {
+      max-width: 600px;
+      max-height: 90vh;
+      overflow-y: auto;
+      border-radius: 12px;
+    }
+
+    h2 {
+      margin: 0 0 16px 0;
+      font-weight: 500;
+      color: var(--primary-text-color);
+    }
+
+    .modal-box[data-size='sm'] h2 {
+      font-size: 18px;
+    }
+
+    .modal-box[data-size='lg'] h2 {
+      font-size: 20px;
+      margin-bottom: 24px;
+    }
+
+    .modal-footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      margin-top: 24px;
+    }
+
+    .modal-box[data-size='lg'] .modal-footer {
+      padding-top: 16px;
+      border-top: 1px solid var(--divider-color, #e0e0e0);
+    }
+
+    ::slotted(p) {
+      margin: 0 0 24px 0;
+      color: var(--secondary-text-color);
+      line-height: 1.5;
+    }
+  `;
+
+  private _onOverlayClick = (e: Event) => {
+    if (!this.dismissOnOverlay) return;
+    if (e.target === e.currentTarget) {
+      this._dismiss();
+    }
+  };
+
+  private _onKeydown = (e: KeyboardEvent) => {
+    if (!this.dismissOnEscape) return;
+    // Note: this fires only when a focused descendant of the overlay receives
+    // the keydown — the overlay <div> itself isn't focusable. Tracked in #28.
+    if (e.key === 'Escape') {
+      this._dismiss();
+    }
+  };
+
+  private _onFooterSlotChange = (e: Event) => {
+    const slot = e.target as HTMLSlotElement;
+    this._hasFooterContent = slot.assignedElements().length > 0;
+  };
+
+  private _dismiss() {
+    this.dispatchEvent(new CustomEvent('dismiss', { bubbles: true, composed: true }));
+  }
+
+  render() {
+    return html`
+      <div
+        class="modal-overlay"
+        @click=${this._onOverlayClick}
+        @keydown=${this._onKeydown}
+      >
+        <div
+          class="modal-box"
+          role=${this.variant}
+          aria-modal="true"
+          aria-labelledby=${this._headingId}
+          data-size=${this.size}
+        >
+          <h2 id=${this._headingId}>${this.heading}</h2>
+          <slot></slot>
+          <div class="modal-footer" ?hidden=${!this._hasFooterContent}>
+            <slot name="footer" @slotchange=${this._onFooterSlotChange}></slot>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'abode-modal': AbodeModal;
+  }
+}

--- a/frontend/src/action-editor.ts
+++ b/frontend/src/action-editor.ts
@@ -7,6 +7,7 @@ import type {
   AlarmEntity,
 } from './types';
 import { fetchSensors, fetchAlarms, createAction, updateAction } from './api';
+import './abode-modal';
 
 type SensorCategory = keyof SensorsByCategory;
 
@@ -29,38 +30,6 @@ export class ActionEditor extends LitElement {
   static styles = css`
     :host {
       display: block;
-    }
-
-    .editor-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgba(0, 0, 0, 0.5);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 1000;
-      padding: 16px;
-    }
-
-    .editor-dialog {
-      background: var(--card-background-color, #fff);
-      border-radius: 12px;
-      padding: 24px;
-      max-width: 600px;
-      width: 100%;
-      max-height: 90vh;
-      overflow-y: auto;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-    }
-
-    h2 {
-      margin: 0 0 24px 0;
-      font-size: 20px;
-      font-weight: 500;
-      color: var(--primary-text-color);
     }
 
     .form-group {
@@ -227,16 +196,10 @@ export class ActionEditor extends LitElement {
       accent-color: var(--primary-color, #03a9f4);
     }
 
-    .button-row {
-      display: flex;
-      justify-content: flex-end;
-      gap: 8px;
-      margin-top: 24px;
-      padding-top: 16px;
-      border-top: 1px solid var(--divider-color, #e0e0e0);
-    }
-
-    .button-row button {
+    /* Footer button styles — applied to <button slot="footer"> inside <abode-modal>.
+     * The selector intentionally matches all slot="footer" buttons in this
+     * shadow root, which today only exist inside <abode-modal>. */
+    button[slot='footer'] {
       padding: 10px 20px;
       border: none;
       border-radius: 4px;
@@ -246,30 +209,30 @@ export class ActionEditor extends LitElement {
       transition: background 0.2s;
     }
 
-    .button-row button.cancel {
+    button[slot='footer'].cancel {
       background: transparent;
       color: var(--secondary-text-color);
     }
 
-    .button-row button.cancel:hover {
+    button[slot='footer'].cancel:hover {
       background: var(--secondary-background-color);
     }
 
-    .button-row button.primary {
+    button[slot='footer'].primary {
       background: var(--primary-color, #03a9f4);
       color: white;
     }
 
-    .button-row button.primary:hover:not(:disabled) {
+    button[slot='footer'].primary:hover:not(:disabled) {
       background: var(--primary-color-dark, #0288d1);
     }
 
-    .button-row button.primary:disabled {
+    button[slot='footer'].primary:disabled {
       opacity: 0.5;
       cursor: not-allowed;
     }
 
-    .button-row button:focus-visible {
+    button[slot='footer']:focus-visible {
       outline: 2px solid var(--primary-color);
       outline-offset: 2px;
     }
@@ -437,37 +400,22 @@ export class ActionEditor extends LitElement {
     this.dispatchEvent(new CustomEvent('cancel'));
   }
 
-  private _handleOverlayClick(e: Event) {
-    if (e.target === e.currentTarget) {
-      this._handleCancel();
-    }
-  }
-
-  private _handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') {
-      this._handleCancel();
-    }
-  }
-
   render() {
     return html`
-      <div
-        class="editor-overlay"
-        @click=${this._handleOverlayClick}
-        @keydown=${this._handleKeydown}
+      <abode-modal
+        heading=${this.action ? 'Edit Action' : 'New Action'}
+        size="lg"
+        @dismiss=${this._handleCancel}
       >
-        <div class="editor-dialog" role="dialog" aria-modal="true" aria-labelledby="editor-title">
-          <h2 id="editor-title">${this.action ? 'Edit Action' : 'New Action'}</h2>
-
-          ${this._loading
-            ? html`<div class="loading">Loading...</div>`
-            : this._renderForm()}
-        </div>
-      </div>
+        ${this._loading
+          ? html`<div class="loading">Loading...</div>`
+          : this._renderFormBody()}
+        ${this._loading ? '' : this._renderFooter()}
+      </abode-modal>
     `;
   }
 
-  private _renderForm() {
+  private _renderFormBody() {
     return html`
       <div class="form-group">
         <label for="action-name">Name</label>
@@ -545,13 +493,22 @@ export class ActionEditor extends LitElement {
             ${this._errors.form}
           </div>`
         : ''}
+    `;
+  }
 
-      <div class="button-row">
-        <button class="cancel" @click=${this._handleCancel}>Cancel</button>
-        <button class="primary" @click=${this._handleSave} ?disabled=${this._saving}>
-          ${this._saving ? 'Saving...' : 'Save'}
-        </button>
-      </div>
+  private _renderFooter() {
+    return html`
+      <button slot="footer" class="cancel" @click=${this._handleCancel}>
+        Cancel
+      </button>
+      <button
+        slot="footer"
+        class="primary"
+        @click=${this._handleSave}
+        ?disabled=${this._saving}
+      >
+        ${this._saving ? 'Saving...' : 'Save'}
+      </button>
     `;
   }
 

--- a/frontend/src/actions-tab.ts
+++ b/frontend/src/actions-tab.ts
@@ -4,6 +4,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import type { HomeAssistant, AbodeAction } from './types';
 import { fetchActions, updateAction, deleteAction, testAction } from './api';
 import './action-editor';
+import './abode-modal';
 
 @customElement('abode-actions-tab')
 export class ActionsTab extends LitElement {
@@ -248,48 +249,7 @@ export class ActionsTab extends LitElement {
       opacity: 1;
     }
 
-    /* Dialog styles */
-    .dialog-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgba(0, 0, 0, 0.5);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 1000;
-    }
-
-    .dialog {
-      background: var(--card-background-color, #fff);
-      border-radius: 8px;
-      padding: 24px;
-      max-width: 400px;
-      width: 90%;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-    }
-
-    .dialog h3 {
-      margin: 0 0 16px 0;
-      font-size: 18px;
-      font-weight: 500;
-      color: var(--primary-text-color);
-    }
-
-    .dialog p {
-      margin: 0 0 24px 0;
-      color: var(--secondary-text-color);
-      line-height: 1.5;
-    }
-
-    .dialog-actions {
-      display: flex;
-      justify-content: flex-end;
-      gap: 8px;
-    }
-
+    /* Dialog button styles — applied to <button slot="footer"> inside <abode-modal>. */
     .dialog-button {
       padding: 8px 16px;
       border: none;
@@ -658,66 +618,58 @@ export class ActionsTab extends LitElement {
 
   private _renderDeleteDialog() {
     return html`
-      <div
-        class="dialog-overlay"
-        @click=${(e: Event) => {
-          if (e.target === e.currentTarget) this._confirm = null;
-        }}
-        @keydown=${(e: KeyboardEvent) => {
-          if (e.key === 'Escape') this._confirm = null;
-        }}
+      <abode-modal
+        heading="Delete Action"
+        variant="alertdialog"
+        @dismiss=${() => (this._confirm = null)}
       >
-        <div class="dialog" role="alertdialog" aria-modal="true" aria-labelledby="delete-title">
-          <h3 id="delete-title">Delete Action</h3>
-          <p>
-            Delete action "${this._confirm?.action.name}"? This cannot be undone.
-          </p>
-          <div class="dialog-actions">
-            <button
-              class="dialog-button cancel"
-              @click=${() => (this._confirm = null)}
-            >
-              Cancel
-            </button>
-            <button class="dialog-button danger" @click=${this._confirmDelete}>
-              Delete
-            </button>
-          </div>
-        </div>
-      </div>
+        <p>
+          Delete action "${this._confirm?.action.name}"? This cannot be undone.
+        </p>
+        <button
+          slot="footer"
+          class="dialog-button cancel"
+          @click=${() => (this._confirm = null)}
+        >
+          Cancel
+        </button>
+        <button
+          slot="footer"
+          class="dialog-button danger"
+          @click=${this._confirmDelete}
+        >
+          Delete
+        </button>
+      </abode-modal>
     `;
   }
 
   private _renderTestDialog() {
     return html`
-      <div
-        class="dialog-overlay"
-        @click=${(e: Event) => {
-          if (e.target === e.currentTarget) this._confirm = null;
-        }}
-        @keydown=${(e: KeyboardEvent) => {
-          if (e.key === 'Escape') this._confirm = null;
-        }}
+      <abode-modal
+        heading="Test Action"
+        variant="alertdialog"
+        @dismiss=${() => (this._confirm = null)}
       >
-        <div class="dialog" role="alertdialog" aria-modal="true" aria-labelledby="test-title">
-          <h3 id="test-title">Test Action</h3>
-          <p>
-            This will trigger real alarms. Are you sure you want to test
-            "${this._confirm?.action.name}"?
-          </p>
-          <div class="dialog-actions">
-            <button
-              class="dialog-button cancel"
-              @click=${() => (this._confirm = null)}
-            >
-              Cancel
-            </button>
-            <button class="dialog-button primary" @click=${this._confirmTest}>
-              Test
-            </button>
-          </div>
-        </div>
-      </div>
+        <p>
+          This will trigger real alarms. Are you sure you want to test
+          "${this._confirm?.action.name}"?
+        </p>
+        <button
+          slot="footer"
+          class="dialog-button cancel"
+          @click=${() => (this._confirm = null)}
+        >
+          Cancel
+        </button>
+        <button
+          slot="footer"
+          class="dialog-button primary"
+          @click=${this._confirmTest}
+        >
+          Test
+        </button>
+      </abode-modal>
     `;
   }
 }


### PR DESCRIPTION
## Summary

PR4 of the frontend sweep. Fixes #32: extract a shared `<abode-modal>` Lit element to dedupe three hand-rolled overlay dialogs (delete-confirm + test-confirm in `actions-tab.ts`, the editor in `action-editor.ts`).

Doing this on `main` before PR5 (a11y) means the focus move/trap/restore + document-level Escape listener will land in one place instead of three.

## API

```ts
<abode-modal
  heading="Delete Action"
  variant="alertdialog"   // default: 'dialog'
  size="sm"               // default: 'sm'  ('lg' = 600px scrollable for editor)
  @dismiss=${onDismiss}
>
  <p>Body content here</p>
  <button slot="footer">Cancel</button>
  <button slot="footer">Confirm</button>
</abode-modal>
```

- Default slot for body, named `footer` slot for the button row.
- Dispatches `dismiss` CustomEvent on overlay click (target===currentTarget) or Escape keydown.
- `dismissOnOverlay` / `dismissOnEscape` flags to opt out per-dialog.
- Internal `<h2>` gets a generated id and is wired via `aria-labelledby` automatically.
- Named `variant` (not `role`) to avoid colliding with `HTMLElement.role` ARIA reflection.

## What changed

- **New:** `frontend/src/abode-modal.ts`, `frontend/src/__tests__/abode-modal.test.ts` (13 tests).
- **Migrated:** delete + test confirms in `actions-tab.ts`, the editor in `action-editor.ts`. Buttons now `slot="footer"` directly (no wrapper div). Old `.dialog*` / `.editor-overlay` / `.editor-dialog` / `.button-row` CSS removed; `.dialog-button*` and footer-button styles retained for slotted buttons.
- **Tests:** 8 existing tests adapted to the new shadow boundary — ARIA correctness now delegated to `abode-modal.test.ts`; consumer tests just verify `<abode-modal>` is rendered with the expected props.
- **Built bundle:** `custom_components/abode_security/www/abode-security-panel.js` regenerated (commit-built-output convention).

## Known limitation (pre-existing)

The Escape `keydown` listener lives on the overlay div, which never receives focus on its own. Pressing Escape only works once a descendant has been tab-focused. Documented inline + in the file header. The focus move/trap + document-level Escape listener is the explicit scope of #28, landing in PR5 (Group A: #9 + #28).

## Test plan

- [x] 13 new tests in `abode-modal.test.ts` (rendering, slot projection, ARIA, both dismiss flags, size attribute).
- [x] All 49 tests pass; `tsc --noEmit` clean; `npm run build` succeeds.
- [x] Visual sanity: `.modal-box[data-size='lg']` preserves the editor's `border-radius: 12px`, `max-height: 90vh`, `overflow-y: auto`, `max-width: 600px` from the old `.editor-dialog`.

Closes #32. Unblocks PR5 (#9 + #28 a11y).
