### PR TITLE
fix(frontend): singular 'action' for count of 1 in modes badge

### DIFF
--- a/custom_components/abode_security/www/abode-security-panel.js
+++ b/custom_components/abode_security/www/abode-security-panel.js
@@ -11,7 +11,7 @@ function t(t,e,o,i){var s,r=arguments.length,n=r<3?e:null===i?i=Object.getOwnPro
           <div class="mode-info">
             <h3>${t.name}</h3>
             <div class="badges">
-              <span class="badge">${t.action_count} actions</span>
+              <span class="badge">${t.action_count} ${1===t.action_count?"action":"actions"}</span>
               ${t.active?B`<span class="badge active">Active</span>`:""}
             </div>
           </div>

--- a/frontend/src/__tests__/modes-tab.test.ts
+++ b/frontend/src/__tests__/modes-tab.test.ts
@@ -35,7 +35,7 @@ describe('ModesTab', () => {
       expect(el.shadowRoot?.textContent).to.include('Away');
     });
 
-    it('shows action counts for each mode', async () => {
+    it('shows plural "actions" for count > 1', async () => {
       const hass = createMockHass();
       const modes = createMockModes();
       modes[1].action_count = 5; // Home mode
@@ -50,10 +50,12 @@ describe('ModesTab', () => {
       el._loading = false;
       await elementUpdated(el);
 
-      expect(el.shadowRoot?.textContent).to.include('5 actions');
+      // Word-boundary anchored — substring match could be satisfied by
+      // unrelated content elsewhere in the tree.
+      expect(el.shadowRoot?.textContent).to.match(/\b5 actions\b/);
     });
 
-    it('shows singular "action" for count of 1', async () => {
+    it('shows singular "action" (no trailing s) for count of 1', async () => {
       const hass = createMockHass();
       const modes = createMockModes();
       modes[0].action_count = 1;
@@ -68,7 +70,31 @@ describe('ModesTab', () => {
       el._loading = false;
       await elementUpdated(el);
 
-      expect(el.shadowRoot?.textContent).to.include('1 action');
+      // The negative-lookahead `(?!s)` is what differentiates this from the
+      // pre-fix substring-only assertion: "1 actions" satisfies `'1 action'`
+      // as a substring, but fails this regex because the next char is `s`.
+      expect(el.shadowRoot?.textContent).to.match(/\b1 action\b(?!s)/);
+    });
+
+    it('shows plural "actions" for count of 0', async () => {
+      // English uses plural for zero ("0 actions"); guards against an
+      // overly-aggressive `=== 1 ? singular : plural` ternary that mistakenly
+      // pluralizes only on count > 1.
+      const hass = createMockHass();
+      const modes = createMockModes();
+      modes[0].action_count = 0;
+
+      const el = await fixture<ModesTab>(html`
+        <abode-modes-tab .hass=${hass}></abode-modes-tab>
+      `);
+
+      // @ts-expect-error - accessing private property for testing
+      el._modes = modes;
+      // @ts-expect-error - accessing private property for testing
+      el._loading = false;
+      await elementUpdated(el);
+
+      expect(el.shadowRoot?.textContent).to.match(/\b0 actions\b/);
     });
 
     it('highlights active mode', async () => {

--- a/frontend/src/modes-tab.ts
+++ b/frontend/src/modes-tab.ts
@@ -210,7 +210,7 @@ export class ModesTab extends LitElement {
           <div class="mode-info">
             <h3>${mode.name}</h3>
             <div class="badges">
-              <span class="badge">${mode.action_count} actions</span>
+              <span class="badge">${mode.action_count} ${mode.action_count === 1 ? 'action' : 'actions'}</span>
               ${mode.active ? html`<span class="badge active">Active</span>` : ''}
             </div>
           </div>


### PR DESCRIPTION
## Summary

Tiny fix — the Modes tab badge always rendered `${count} actions` regardless of count, producing "1 actions" for single-action modes. The pre-existing unit test asserted `.to.include('1 action')`, which is satisfied by "1 actions" as a substring — so it silently passed against the bug.

## Fix

```ts
${mode.action_count} ${mode.action_count === 1 ? 'action' : 'actions'}
```

## Test changes

Replaced the loose substring match with three regex assertions covering both directions:
- `shows plural "actions" for count > 1` — `\b5 actions\b`
- `shows singular "action" (no trailing s) for count of 1` — `\b1 action\b(?!s)` (this is the failing-first test that drove the fix)
- `shows plural "actions" for count of 0` — `\b0 actions\b` (guards against an over-aggressive `count > 1 ? 'actions' : 'action'` regression)

## Note on scope

Issue #1 (originally bundled with #24 in the master plan) turned out to be a feature request — adding actual mode-switching UI from the panel, not a label tweak. Descoped to a separate PR (PR8.5) so this stays a clean tiny-fix PR.

## Test plan

- [x] `npm --prefix frontend test` — 70 passing (was 69; tightened test variants)
- [x] `npm --prefix frontend run typecheck` — clean
- [x] `npm --prefix frontend run build` — bundle rebuilt
- [x] `/pre-commit-review` — APPROVED, no findings

Closes #24.
