### PR TITLE
fix(backend): resolve Abode alarm panel via entity registry

### DIFF
--- a/custom_components/abode_security/action_trigger.py
+++ b/custom_components/abode_security/action_trigger.py
@@ -15,6 +15,7 @@ from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
 
 from .const import DOMAIN
+from .helpers import find_abode_alarm_panel
 
 if TYPE_CHECKING:
     from .action_manager import AbodeAction, ActionManager
@@ -76,10 +77,10 @@ class ActionTriggerCoordinator:
         Returns:
             Mode string ('standby', 'home', 'away') or None if no alarm panel found.
         """
-        for state in self._hass.states.async_all("alarm_control_panel"):
-            if state.entity_id.startswith("alarm_control_panel.abode"):
-                return STATE_TO_MODE.get(state.state)
-        return None
+        panel_state = find_abode_alarm_panel(self._hass)
+        if panel_state is None:
+            return None
+        return STATE_TO_MODE.get(panel_state.state)
 
     @callback
     def _handle_state_change(self, event: Event) -> None:

--- a/custom_components/abode_security/helpers.py
+++ b/custom_components/abode_security/helpers.py
@@ -1,0 +1,40 @@
+"""Shared helpers for the Abode Security integration."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN
+
+
+def find_abode_alarm_panel(hass: HomeAssistant) -> State | None:
+    """Return the State of the Abode alarm_control_panel, or None.
+
+    Resolves via the entity registry first (matches platform=DOMAIN
+    + domain="alarm_control_panel"), so a user-renamed entity_id still
+    resolves correctly.
+
+    Falls back to a `state.entity_id.startswith("alarm_control_panel.abode")`
+    scan for two cases:
+      1. Older installs that pre-date config-entry registration with the
+         current platform name.
+      2. Test scenarios that set states directly via `hass.states.async_set`
+         without going through the entity registry.
+
+    Both `websocket_api` (modes/list, modes/set) and `action_trigger` use
+    this helper to resolve the panel — keeping the lookup in one place
+    eliminates the prefix-match drift that was previously duplicated
+    between the two modules (#44).
+    """
+    registry = er.async_get(hass)
+    for entry in registry.entities.values():
+        if entry.domain == "alarm_control_panel" and entry.platform == DOMAIN:
+            state = hass.states.get(entry.entity_id)
+            if state is not None:
+                return state
+
+    for state in hass.states.async_all("alarm_control_panel"):
+        if state.entity_id.startswith("alarm_control_panel.abode"):
+            return state
+    return None

--- a/custom_components/abode_security/websocket_api.py
+++ b/custom_components/abode_security/websocket_api.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import config_validation as cv
 
 from .action_manager import VALID_MODES
 from .const import DOMAIN
+from .helpers import find_abode_alarm_panel
 
 if TYPE_CHECKING:
     from homeassistant.components.websocket_api import ActiveConnection
@@ -359,17 +360,9 @@ assert set(MODE_TO_SERVICE) == VALID_MODES, (
 )
 
 
-def _find_abode_alarm(hass: HomeAssistant):
-    """Return the State of the Abode alarm_control_panel, or None.
-
-    Both `_modes_list` (reads `state.state` to compute the active mode) and
-    `_modes_set` (uses `state.entity_id` to target the service call) need
-    the same lookup, so they share this helper.
-    """
-    for state in hass.states.async_all("alarm_control_panel"):
-        if state.entity_id.startswith("alarm_control_panel.abode"):
-            return state
-    return None
+# `find_abode_alarm_panel` (resolves the panel via entity registry, falling
+# back to entity_id prefix) lives in `helpers` so `action_trigger` can share
+# the same lookup. See helpers.py for the rationale.
 
 
 @websocket_api.websocket_command(
@@ -387,7 +380,7 @@ async def websocket_modes_list(
     action_manager = _get_action_manager(hass)
 
     # Find the active mode from the abode alarm_control_panel entity, if any.
-    panel_state = _find_abode_alarm(hass)
+    panel_state = find_abode_alarm_panel(hass)
     active_mode = STATE_TO_MODE.get(panel_state.state) if panel_state else None
 
     # Build mode list with action counts
@@ -441,7 +434,7 @@ async def websocket_modes_set(
     """
     mode_id = msg["mode_id"]
 
-    panel_state = _find_abode_alarm(hass)
+    panel_state = find_abode_alarm_panel(hass)
     if panel_state is None:
         connection.send_error(
             msg["id"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,6 +231,8 @@ def pytest_collection_modifyitems(config, items):
         "test_ws_modes_set_standby",
         "test_ws_modes_set_invalid_mode",
         "test_ws_modes_set_no_panel",
+        "test_ws_modes_set_finds_renamed_entity_via_registry",
+        "test_ws_modes_list_finds_renamed_entity_via_registry",
         "test_ws_entities_sensors_empty",
         "test_ws_entities_sensors_grouped_by_device_class",
         "test_ws_entities_sensors_includes_state",

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -1,6 +1,7 @@
 """Tests for the WebSocket API module."""
 
 import pytest
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.abode_security.action_manager import ActionManager
 from custom_components.abode_security.config_store import ConfigStore
@@ -726,6 +727,71 @@ class TestWebSocketModesAPI:
 
         assert not response["success"]
         assert response["error"]["code"] == "not_found"
+
+    async def test_ws_modes_set_finds_renamed_entity_via_registry(
+        self, hass, hass_ws_client
+    ) -> None:
+        """Renamed entity_id (e.g. alarm_control_panel.house) still resolves
+        via entity registry lookup by platform=abode_security (#44).
+
+        The pre-fix prefix heuristic (`startswith("alarm_control_panel.abode")`)
+        misses any user-renamed entity. Registering with a non-standard entity_id
+        in the entity registry simulates a rename: the registry entry retains
+        platform=abode_security regardless of what the user renames it to.
+        """
+        registry = er.async_get(hass)
+        # Register an Abode alarm panel under a non-prefix entity_id.
+        registry.async_get_or_create(
+            domain="alarm_control_panel",
+            platform=DOMAIN,
+            unique_id="abode-test-uid",
+            suggested_object_id="house",  # → alarm_control_panel.house
+        )
+        hass.states.async_set("alarm_control_panel.house", "disarmed")
+
+        calls = []
+
+        async def mock_service(call):
+            calls.append(call)
+
+        hass.services.async_register(
+            "alarm_control_panel", "alarm_arm_home", mock_service
+        )
+
+        client = await hass_ws_client(hass)
+        await client.send_json(
+            {
+                "id": 1,
+                "type": "abode_security/modes/set",
+                "mode_id": "home",
+            }
+        )
+        response = await client.receive_json()
+
+        assert response["success"]
+        assert len(calls) == 1
+        assert calls[0].data["entity_id"] == "alarm_control_panel.house"
+
+    async def test_ws_modes_list_finds_renamed_entity_via_registry(
+        self, hass, hass_ws_client
+    ) -> None:
+        """Active-mode flag must resolve correctly even after entity rename (#44)."""
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            domain="alarm_control_panel",
+            platform=DOMAIN,
+            unique_id="abode-test-uid-list",
+            suggested_object_id="my_security_system",
+        )
+        hass.states.async_set("alarm_control_panel.my_security_system", "armed_home")
+
+        client = await hass_ws_client(hass)
+        await client.send_json({"id": 1, "type": "abode_security/modes/list"})
+        response = await client.receive_json()
+
+        assert response["success"]
+        home_mode = next(m for m in response["result"]["modes"] if m["id"] == "home")
+        assert home_mode["active"] is True
 
 
 @pytest.mark.usefixtures("mock_abode", "setup_websocket_api")


### PR DESCRIPTION
## Summary

Two backend code paths previously located the Abode `alarm_control_panel` entity by **entity_id prefix match** (`startswith("alarm_control_panel.abode")`):

- `websocket_api._find_abode_alarm` (used by `modes/list` for the active flag and `modes/set` to target the service call)
- `action_trigger._get_current_mode` (gates sensor-driven triggers by current mode)

Home Assistant lets users rename entity_ids; if the user renames the abode panel away from the default, **both paths silently fail**:
- `modes/list` never marks any mode active
- `modes/set` returns `not_found`
- Action triggers stop firing for the current mode

Closes #44 (raised by Copilot during PR #43 review).

## Fix

New shared `helpers.py` module exposes `find_abode_alarm_panel(hass) -> State | None`:

```python
def find_abode_alarm_panel(hass: HomeAssistant) -> State | None:
    registry = er.async_get(hass)
    for entry in registry.entities.values():
        if entry.domain == "alarm_control_panel" and entry.platform == DOMAIN:
            state = hass.states.get(entry.entity_id)
            if state is not None:
                return state

    # Fallback for old installs / tests that set states directly without
    # registering with the entity registry.
    for state in hass.states.async_all("alarm_control_panel"):
        if state.entity_id.startswith("alarm_control_panel.abode"):
            return state
    return None
```

The registry entry is preserved across user renames, so this resolves correctly. The prefix-scan fallback is retained for backwards compat (test_action_trigger.py, very old installs) — a follow-up can drop it once tests migrate to entity-registry fixtures.

## Changes

- **New** `custom_components/abode_security/helpers.py` — shared helper
- `websocket_api.py` — removed local `_find_abode_alarm`, two callsites use the shared helper
- `action_trigger.py` — `_get_current_mode` simplified from inline scan to helper call
- `tests/test_websocket_api.py` — 2 new tests (`test_ws_modes_set_finds_renamed_entity_via_registry`, `test_ws_modes_list_finds_renamed_entity_via_registry`) that register an Abode panel under a non-prefix entity_id (e.g. `alarm_control_panel.house`) and assert the registry path resolves it
- `tests/conftest.py` — 2 new test names added to `enabled_tests`

## Test plan

- [x] `./scripts/check.sh` — 165 Python tests pass (was 163; +2 new), ruff + mypy clean
- [x] Existing fallback-path tests (`test_coordinator_get_mode_*` x4, `test_ws_modes_set_*` x5, `test_ws_modes_list_*` x5) still green via prefix-scan fallback
- [x] `/pre-commit-review` — APPROVED after one round (5 suggestions: 2 addressed in code, 3 declined with reasoning)

## Notes

- Reviewer suggested using indexed `er.async_entries_for_config_entry` (PR #43 declares `single_config_entry: true`). Microsecond-scale optimization on a small registry — deferred to a follow-up.
- `helpers.py` is named at the integration root to match HA convention (e.g. `homeassistant.components.abode.helpers`, `unifi.helpers`, etc.). The path doesn't conflict with the embedded `abode/helpers/` library.
