### PR TITLE
fix(security): redact tokens and PII from DEBUG response logs

### DIFF
--- a/custom_components/abode_security/abode/client.py
+++ b/custom_components/abode_security/abode/client.py
@@ -8,6 +8,7 @@ import json as json_module
 import logging
 import uuid
 from datetime import datetime, timedelta
+from typing import Any
 
 import aiohttp
 
@@ -21,6 +22,55 @@ from .exceptions import AuthenticationException, Exception, RateLimitException
 from .helpers import errors, urls
 
 log = logging.getLogger(__name__)
+
+
+# Keys whose values must never appear in DEBUG logs. Compared case-insensitively
+# against dict keys at every level of nested response bodies. See issue #49.
+_REDACT_KEYS = frozenset(
+    {
+        "token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "password",
+        "cookie",
+        "set-cookie",
+        "email",
+        "phone",
+        "uuid",
+        "mfa_code",
+    }
+)
+
+
+def _redact(payload: Any) -> Any:
+    """Return a copy of ``payload`` with secret-looking values masked.
+
+    Walks dicts and lists recursively, masking values whose key matches
+    ``_REDACT_KEYS`` (case-insensitive). Primitives are returned unchanged.
+    The input is not mutated.
+    """
+    if isinstance(payload, dict):
+        return {
+            k: ("<redacted>" if k.lower() in _REDACT_KEYS else _redact(v))
+            for k, v in payload.items()
+        }
+    if isinstance(payload, list):
+        return [_redact(x) for x in payload]
+    return payload
+
+
+def _redact_text(raw: str) -> str:
+    """Redact a raw response-body string before logging.
+
+    If ``raw`` parses as JSON, apply :func:`_redact` and re-serialize so the
+    log line stays readable. Otherwise, log a structural summary (length only)
+    rather than the body itself — opaque bodies can still contain secrets.
+    """
+    try:
+        return json_module.dumps(_redact(json_module.loads(raw)))
+    except (ValueError, TypeError):
+        return f"<non-json body len={len(raw) if raw is not None else 0}>"
 
 
 class Everything:
@@ -303,7 +353,7 @@ class Client:
             oauth_response_object = await oauth_response.json()
 
         log.debug("Login URL: %s", urls.LOGIN)
-        log.debug("Login Response: %s", response_object)
+        log.debug("Login Response: %s", _redact(response_object))
 
         self._token = response_object["token"]
         self._panel = response_object["panel"]
@@ -348,7 +398,7 @@ class Client:
             ) as response:
                 await AuthenticationException.raise_for(response)
                 log.debug("Logout URL: %s", urls.LOGOUT)
-                log.debug("Logout Response: %s", await response.text())
+                log.debug("Logout Response: %s", _redact_text(await response.text()))
         except (aiohttp.ClientError, OSError) as exc:
             log.warning("Caught exception during logout: %s", exc)
             return
@@ -599,7 +649,7 @@ class Client:
         devices = always_iterable(devices_data)
 
         log.debug("Get Devices URL (get): %s", urls.DEVICES)
-        log.debug("Get Devices Response: %s", devices_data)
+        log.debug("Get Devices Response: %s", _redact(devices_data))
 
         for device_doc in devices:
             await self._load_device(device_doc)
@@ -611,7 +661,7 @@ class Client:
         self._panel.update(panel_data)
 
         log.debug("Get Mode Panel URL (get): %s", urls.PANEL)
-        log.debug("Get Mode Panel Response: %s", panel_data)
+        log.debug("Get Mode Panel Response: %s", _redact(panel_data))
 
         alarm_device = self._devices.get(alarm.id(1))
 
@@ -682,7 +732,7 @@ class Client:
         else:
             resp_data = await resp.json()
         log.debug("Get Automations URL (get): %s", urls.AUTOMATION)
-        log.debug("Get Automations Response: %s", resp_data)
+        log.debug("Get Automations Response: %s", _redact(resp_data))
 
         for state in always_iterable(resp_data):
             # Attempt to reuse an existing automation object
@@ -762,7 +812,9 @@ class Client:
             raise Exception(errors.REQUEST)
 
         log.debug("Timeline Event URL (post): %s", url)
-        log.debug("Timeline Event Response: %s", await response.text())
+        log.debug(
+            "Timeline Event Response: %s", _redact_text(await response.text())
+        )
 
         # Check if request was successful
         if response.status < 400:
@@ -823,7 +875,7 @@ class Client:
 
         timeline_events = await response.json()
 
-        log.debug("Get Timeline Events Response: %s", timeline_events)
+        log.debug("Get Timeline Events Response: %s", _redact(timeline_events))
 
         if not isinstance(timeline_events, list):
             log.warning(
@@ -968,7 +1020,7 @@ class Client:
             return {}
 
         log.debug("Get CMS Settings URL (get): %s", urls.SECURITY_PANEL)
-        log.debug("Get CMS Settings Response (parsed): %s", response_data)
+        log.debug("Get CMS Settings Response (parsed): %s", _redact(response_data))
 
         return response_data.get("attributes", {}).get("cms", {}) or {}
 
@@ -1008,7 +1060,7 @@ class Client:
                 return {}
 
         log.debug("Get CMS Settings URL (get): %s", urls.CMS_SETTINGS)
-        log.debug("Get CMS Settings Response (parsed): %s", response_data)
+        log.debug("Get CMS Settings Response (parsed): %s", _redact(response_data))
         return response_data if isinstance(response_data, dict) else {}
 
     @staticmethod
@@ -1069,7 +1121,7 @@ class Client:
         response_object = await response.json()
 
         log.debug("Set CMS Setting URL (post): %s", urls.CMS_SETTINGS)
-        log.debug("Set CMS Setting Response (parsed): %s", response_object)
+        log.debug("Set CMS Setting Response (parsed): %s", _redact(response_object))
 
         response_object = response_object if isinstance(response_object, dict) else {}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,6 +322,16 @@ def pytest_collection_modifyitems(config, items):
         "test_alarm_attached_device_info_consistent_manual_alarm",
         "test_alarm_attached_device_info_consistent_cms",
         "test_alarm_attached_device_info_consistent_test_mode",
+        # Debug-log redaction (issue #49)
+        "test_login_response_redacts_token_and_user_pii",
+        "test_oauth_nested_dict_is_redacted",
+        "test_redact_is_case_insensitive",
+        "test_redact_walks_lists",
+        "test_redact_passes_through_primitives",
+        "test_redact_does_not_mutate_input",
+        "test_redact_text_handles_json_payload",
+        "test_redact_text_returns_summary_for_non_json",
+        "test_login_debug_log_redacts_token",
     }
     # Skip tests with hass fixture except enabled tests
     for item in items:

--- a/tests/test_client_redact.py
+++ b/tests/test_client_redact.py
@@ -1,0 +1,160 @@
+"""Tests for the debug-log redaction helper in ``abode/client.py``.
+
+Covers issue #49: tokens and other secrets must not appear in DEBUG logs that
+users routinely paste into GitHub/community forums.
+"""
+
+import json
+import logging
+
+import pytest
+
+from custom_components.abode_security.abode import client as client_module
+
+SECRET_TOKEN = "live-session-token-aaaaaaaaaaaaaaaaaa"
+SECRET_ACCESS = "live-access-token-bbbbbbbbbbbbbbbbbbbbbbbb"
+SECRET_REFRESH = "live-refresh-cccccccccccccccccccccccc"
+SECRET_PASSWORD = "hunter2-supersecret"
+
+
+def _flatten(value):
+    """Render any value into a single string for substring assertions."""
+    if isinstance(value, dict | list):
+        return json.dumps(value)
+    return str(value)
+
+
+class TestRedact:
+    """Unit tests for ``client._redact``."""
+
+    def test_login_response_redacts_token_and_user_pii(self) -> None:
+        payload = {
+            "token": SECRET_TOKEN,
+            "panel": {"mac": "AA:BB:CC:DD:EE:FF"},
+            "user": {
+                "email": "victim@example.com",
+                "phone": "+15551234567",
+                "uuid": "11111111-2222-3333-4444-555555555555",
+            },
+        }
+
+        redacted = client_module._redact(payload)
+
+        assert redacted["token"] == "<redacted>"
+        assert redacted["user"]["email"] == "<redacted>"
+        assert redacted["user"]["phone"] == "<redacted>"
+        assert redacted["user"]["uuid"] == "<redacted>"
+        # Non-secret fields are preserved.
+        assert redacted["panel"]["mac"] == "AA:BB:CC:DD:EE:FF"
+        # The secret string itself must not survive anywhere in the structure.
+        assert SECRET_TOKEN not in _flatten(redacted)
+
+    def test_oauth_nested_dict_is_redacted(self) -> None:
+        payload = {
+            "outer": {
+                "access_token": SECRET_ACCESS,
+                "refresh_token": SECRET_REFRESH,
+                "id_token": "id.jwt.value",
+                "expires_in": 3600,
+            }
+        }
+
+        redacted = client_module._redact(payload)
+
+        assert redacted["outer"]["access_token"] == "<redacted>"
+        assert redacted["outer"]["refresh_token"] == "<redacted>"
+        assert redacted["outer"]["id_token"] == "<redacted>"
+        assert redacted["outer"]["expires_in"] == 3600
+        assert SECRET_ACCESS not in _flatten(redacted)
+        assert SECRET_REFRESH not in _flatten(redacted)
+
+    def test_redact_is_case_insensitive(self) -> None:
+        payload = {"Token": SECRET_TOKEN, "Set-Cookie": "session=abc"}
+
+        redacted = client_module._redact(payload)
+
+        assert redacted["Token"] == "<redacted>"
+        assert redacted["Set-Cookie"] == "<redacted>"
+
+    def test_redact_walks_lists(self) -> None:
+        payload = [
+            {"token": SECRET_TOKEN, "name": "Front Door"},
+            {"password": SECRET_PASSWORD, "name": "Back Door"},
+        ]
+
+        redacted = client_module._redact(payload)
+
+        assert redacted[0]["token"] == "<redacted>"
+        assert redacted[0]["name"] == "Front Door"
+        assert redacted[1]["password"] == "<redacted>"
+        assert SECRET_TOKEN not in _flatten(redacted)
+        assert SECRET_PASSWORD not in _flatten(redacted)
+
+    def test_redact_passes_through_primitives(self) -> None:
+        assert client_module._redact("hello") == "hello"
+        assert client_module._redact(42) == 42
+        assert client_module._redact(None) is None
+        assert client_module._redact(True) is True
+
+    def test_redact_does_not_mutate_input(self) -> None:
+        payload = {"token": SECRET_TOKEN, "nested": {"access_token": SECRET_ACCESS}}
+        original = json.loads(json.dumps(payload))
+
+        client_module._redact(payload)
+
+        assert payload == original
+
+
+class TestRedactText:
+    """``_redact_text`` parses JSON-shaped strings, redacts, and re-serializes."""
+
+    def test_redact_text_handles_json_payload(self) -> None:
+        raw = json.dumps({"token": SECRET_TOKEN, "status": "ok"})
+
+        result = client_module._redact_text(raw)
+
+        assert "<redacted>" in result
+        assert SECRET_TOKEN not in result
+        assert "ok" in result
+
+    def test_redact_text_returns_summary_for_non_json(self) -> None:
+        raw = "not-json-but-might-contain-token=" + SECRET_TOKEN
+
+        result = client_module._redact_text(raw)
+
+        assert SECRET_TOKEN not in result
+        # Should communicate something about the body without leaking it.
+        assert "len=" in result or "non-json" in result.lower()
+
+
+class TestDebugLogsAreClean:
+    """Capture debug logs at the integration points and grep for secrets."""
+
+    def _set_token_and_session(self, client):
+        """Bypass ``__init__`` defaults for tests that don't need a real session."""
+        client._session = object()
+        client._token = "preexisting"
+
+    @pytest.mark.asyncio
+    async def test_login_debug_log_redacts_token(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Simulate the login log line and assert the token is redacted."""
+        # We don't drive the real ``login()`` (it needs HTTP); we replay the
+        # specific ``log.debug`` call that ``login()`` makes after parsing the
+        # response, which is the exact line called out in the issue.
+        response_object = {
+            "token": SECRET_TOKEN,
+            "panel": {"mac": "AA:BB:CC:DD:EE:FF"},
+            "user": {"email": "victim@example.com"},
+        }
+
+        with caplog.at_level(logging.DEBUG, logger=client_module.log.name):
+            client_module.log.debug(
+                "Login Response: %s", client_module._redact(response_object)
+            )
+
+        rendered = "\n".join(record.getMessage() for record in caplog.records)
+        assert SECRET_TOKEN not in rendered
+        assert "victim@example.com" not in rendered
+        assert "<redacted>" in rendered


### PR DESCRIPTION
## Summary

- Add `_redact()` / `_redact_text()` helpers to `abode/client.py` that mask secret-bearing keys (`token`, `access_token`, `refresh_token`, `id_token`, `password`, `cookie`, `set-cookie`, `email`, `phone`, `uuid`, `mfa_code`) before they hit DEBUG logs.
- Route every `log.debug("... Response: %s", ...)` call site through one of those helpers — covers the seven sites called out in the issue (login, logout, devices, panel, automations, timeline event, timeline events) plus three CMS-settings sites so the acceptance criterion holds file-wide.
- Add `tests/test_client_redact.py` with 9 unit tests, including a substring-match probe to verify the raw secret string never survives anywhere in the redacted output.

## Root cause

`abode/client.py` emitted full HTTP response bodies at DEBUG level. The integration's `CONF_DEBUG_LOGGING` option flips this logger to DEBUG (`__init__.py:125-129`), and HA users routinely paste debug logs into GitHub issues / community forums — so live session tokens and OAuth `access_token`s were being shared whenever debug logging was on.

## Test plan

- [x] `tests/test_client_redact.py` — 9 new tests, RED-then-GREEN
- [x] Verified RED phase: tests fail with `AttributeError: ... has no attribute '_redact'` before the helper exists
- [x] Verified GREEN phase: all 9 tests pass after implementation
- [x] `./scripts/check.sh` — ruff + mypy + full pytest suite all green (174 passed, no new failures)
- [x] `grep "log.debug.*Response" custom_components/abode_security/abode/client.py` — every match goes through `_redact` or `_redact_text` (the one remaining match logs only `response.status`)

## Notes

- `tests/conftest.py` allowlist updated to enable the 9 new tests — required because an autouse fixture pulls `hass` transitively into every test's fixturenames; documented in `CLAUDE.md`'s "Testing gotchas" section.
- The vendored library's pre-existing Pyright noise (None-member access in `client.py`) is out of scope and unchanged.

Fixes #49
