### PR TITLE
fix(security): redact PII from diagnostics output (#50)

### DIFF
--- a/custom_components/abode_security/diagnostics.py
+++ b/custom_components/abode_security/diagnostics.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .models import AbodeSystem
+
+# unique_id is the user's Abode username (an email) — see config_flow.py.
+# Other keys are listed defensively for future additions to the payload.
+TO_REDACT = {"unique_id", "email", "username", "phone", "cookie", "token", "password"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -76,7 +81,7 @@ async def async_get_config_entry_diagnostics(
     except (AttributeError, TypeError):
         connection_diagnostics = {"status": "unavailable"}
 
-    return {
+    payload = {
         "polling": abode_system.polling,
         "polling_interval": abode_system.polling_interval,
         "enable_events": abode_system.enable_events,
@@ -93,3 +98,4 @@ async def async_get_config_entry_diagnostics(
         },
         "unique_id": entry.unique_id,
     }
+    return async_redact_data(payload, TO_REDACT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,6 +332,9 @@ def pytest_collection_modifyitems(config, items):
         "test_redact_text_handles_json_payload",
         "test_redact_text_returns_summary_for_non_json",
         "test_login_debug_log_redacts_token",
+        # Diagnostics PII redaction (issue #50)
+        "test_unique_id_is_redacted",
+        "test_email_does_not_appear_anywhere_in_payload",
     }
     # Skip tests with hass fixture except enabled tests
     for item in items:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,57 @@
+"""Tests for the diagnostics payload (issue #50).
+
+The integration sets ``ConfigEntry.unique_id`` to the user's Abode username,
+which is their email address. Diagnostics bundles are routinely attached to
+support tickets and public forum threads, so any PII must be redacted before
+it leaves the user's instance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.abode_security import diagnostics
+
+EMAIL = "victim@example.com"
+
+
+def _run_diagnostics() -> dict:
+    """Build minimal mocks and call ``async_get_config_entry_diagnostics``."""
+    abode_system = MagicMock()
+    abode_system.polling = True
+    abode_system.polling_interval = 30
+    abode_system.enable_events = True
+    abode_system.retry_count = 3
+    abode_system.abode.get_devices = AsyncMock(return_value=[])
+    abode_system.abode.get_automations = AsyncMock(return_value=[])
+    abode_system.abode.get_alarm = MagicMock(
+        return_value=MagicMock(type="alarm", battery="ok")
+    )
+    abode_system.abode.events.connected = True
+    abode_system.abode.connection_diagnostics = {"status": "ok"}
+
+    entry = MagicMock()
+    entry.runtime_data = abode_system
+    entry.unique_id = EMAIL
+
+    return asyncio.run(
+        diagnostics.async_get_config_entry_diagnostics(MagicMock(), entry)
+    )
+
+
+class TestDiagnosticsRedaction:
+    """The diagnostics payload must not leak the user's email or other PII."""
+
+    def test_unique_id_is_redacted(self) -> None:
+        result = _run_diagnostics()
+
+        assert result["unique_id"] == "**REDACTED**"
+
+    def test_email_does_not_appear_anywhere_in_payload(self) -> None:
+        result = _run_diagnostics()
+
+        # JSON-serialize the whole payload and grep for the email — this is the
+        # exact failure mode the issue describes (PII reaching a support ticket).
+        assert EMAIL not in json.dumps(result, default=str)


### PR DESCRIPTION
## Summary

- Wrap the diagnostics payload with HA's `async_redact_data` so PII never leaves the user's instance.
- `TO_REDACT` covers `unique_id` (the actual leak — set to the user's email by config_flow) plus `email`, `username`, `phone`, `cookie`, `token`, `password` as a defensive whitelist for future additions.
- New `tests/test_diagnostics.py` mocks `ConfigEntry`/`AbodeSystem`, runs the diagnostics fn, and asserts the email never appears in the JSON-serialized output and `unique_id` is `**REDACTED**`.

## Root cause

`config_flow.py:160` calls `async_set_unique_id(self._username)`, where `_username` is the user's Abode email. `diagnostics.py:94` then echoed `entry.unique_id` verbatim into the diagnostics bundle. Those bundles are routinely attached to support tickets and forum threads.

## Test plan

- [x] Added test that reproduces the bug (email present in JSON output, `unique_id` leaks)
- [x] Verified test fails before fix, passes after
- [x] Full test suite passes with no regressions (`./scripts/check.sh`)

Fixes #50
