### PR TITLE
fix(types): correct override() annotation and enable mypy strict (#57, #56)

### DIFF
--- a/custom_components/abode_security/__init__.py
+++ b/custom_components/abode_security/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from functools import partial
 from pathlib import Path
+from typing import cast
 
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
@@ -298,7 +299,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop("config", None)
         hass.data[DOMAIN].pop("config_store", None)
 
-    return unload_ok
+    return cast(bool, unload_ok)
 
 
 async def async_setup_hass_events(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/abode_security/abode/config.py
+++ b/custom_components/abode_security/abode/config.py
@@ -8,7 +8,6 @@ True
 from __future__ import annotations
 
 import pathlib
-from collections.abc import Mapping
 
 import platformdirs
 
@@ -31,7 +30,7 @@ class PlatformDirs(platformdirs.PlatformDirs):
     def user_data_path(self):
         return vars(self).get('user_data_path') or super().user_data_path
 
-    def override(self, **kwargs: Mapping[str, pathlib.Path]):
+    def override(self, **kwargs: pathlib.Path) -> None:
         """
         Override the default _path variable.
 

--- a/custom_components/abode_security/action_manager.py
+++ b/custom_components/abode_security/action_manager.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.storage import Store
 
@@ -270,7 +270,7 @@ class ActionManager:
         """Get all actions."""
         return self._store.get_all()
 
-    async def async_update(self, action_id: str, **kwargs) -> AbodeAction | None:
+    async def async_update(self, action_id: str, **kwargs: Any) -> AbodeAction | None:
         """Update an action with the provided fields.
 
         Args:

--- a/custom_components/abode_security/config_flow.py
+++ b/custom_components/abode_security/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import selector
-from requests.exceptions import (  # type: ignore[import-untyped]
+from requests.exceptions import (
     ConnectTimeout,
     HTTPError,
 )

--- a/custom_components/abode_security/diagnostics.py
+++ b/custom_components/abode_security/diagnostics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
@@ -98,4 +98,4 @@ async def async_get_config_entry_diagnostics(
         },
         "unique_id": entry.unique_id,
     }
-    return async_redact_data(payload, TO_REDACT)
+    return cast(dict[str, Any], async_redact_data(payload, TO_REDACT))

--- a/custom_components/abode_security/light.py
+++ b/custom_components/abode_security/light.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import ceil
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -107,11 +107,11 @@ class AbodeLight(AbodeDevice, LightEntity):
         """Return the color mode of the light."""
         if self._device.is_dimmable and self._device.is_color_capable:
             if self.hs_color is not None:
-                return ColorMode.HS
-            return ColorMode.COLOR_TEMP
+                return cast(str, ColorMode.HS)
+            return cast(str, ColorMode.COLOR_TEMP)
         if self._device.is_dimmable:
-            return ColorMode.BRIGHTNESS
-        return ColorMode.ONOFF
+            return cast(str, ColorMode.BRIGHTNESS)
+        return cast(str, ColorMode.ONOFF)
 
     @property
     def supported_color_modes(self) -> set[str] | None:

--- a/custom_components/abode_security/models.py
+++ b/custom_components/abode_security/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from homeassistant.core import CALLBACK_TYPE
 
@@ -207,7 +207,7 @@ class AbodeSystem:
                 "get_test_mode() returned: %s (type: %s)", result, type(result)
             )
             self.test_mode_supported = getattr(self.abode, "test_mode_supported", True)
-            return result
+            return cast(bool, result)
         except AttributeError:
             LOGGER.debug("get_test_mode method not available in abode client")
             return False

--- a/custom_components/abode_security/services.py
+++ b/custom_components/abode_security/services.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import voluptuous as vol
 from homeassistant.const import ATTR_ENTITY_ID
@@ -91,7 +91,7 @@ def _get_abode_system(hass: HomeAssistant) -> AbodeSystem | None:
     """Get the AbodeSystem from the first available config entry."""
     for entry in hass.config_entries.async_entries(DOMAIN):
         if entry.runtime_data:
-            return entry.runtime_data
+            return cast("AbodeSystem", entry.runtime_data)
     return None
 
 

--- a/custom_components/abode_security/websocket_api.py
+++ b/custom_components/abode_security/websocket_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import voluptuous as vol
 from homeassistant.components import websocket_api
@@ -18,6 +18,9 @@ from .helpers import find_abode_alarm_panel
 
 if TYPE_CHECKING:
     from homeassistant.components.websocket_api import ActiveConnection
+
+    from .action_manager import ActionManager
+    from .config_store import ConfigStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,9 +45,9 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_config_set)
 
 
-def _get_action_manager(hass: HomeAssistant):
+def _get_action_manager(hass: HomeAssistant) -> ActionManager | None:
     """Get the ActionManager from hass.data."""
-    return hass.data.get(DOMAIN, {}).get("action_manager")
+    return cast("ActionManager | None", hass.data.get(DOMAIN, {}).get("action_manager"))
 
 
 # --- Action CRUD Endpoints ---
@@ -547,9 +550,9 @@ async def websocket_entities_alarms(
 # --- Config Endpoints ---
 
 
-def _get_config_store(hass: HomeAssistant):
+def _get_config_store(hass: HomeAssistant) -> ConfigStore | None:
     """Get the ConfigStore from hass.data."""
-    return hass.data.get(DOMAIN, {}).get("config_store")
+    return cast("ConfigStore | None", hass.data.get(DOMAIN, {}).get("config_store"))
 
 
 @websocket_api.websocket_command(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,10 @@ ignore = ["E501", "N812", "N818"]  # Naming conventions in vendored library
 [tool.mypy]
 python_version = "3.11"
 check_untyped_defs = true
-disallow_untyped_defs = false
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_return_any = true
+warn_unused_ignores = true
 ignore_missing_imports = true
 follow_imports = "skip"
 exclude = [

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["custom_components/abode_security"],
+  "exclude": [
+    "custom_components/abode_security/abode",
+    "tests",
+    "**/__pycache__",
+    "**/node_modules"
+  ],
+  "pythonVersion": "3.11",
+  "reportUnusedParameter": "none"
+}


### PR DESCRIPTION
## Summary

- Fix wrong `**kwargs` type annotation on `PlatformDirs.override()` in the vendored library (#57) — `**kwargs: Mapping[str, pathlib.Path]` declared each value as a mapping, not a `Path`. Pyright correctly flagged the `__init__.py:133` call site.
- Add a project-level `pyrightconfig.json` that scopes Pyright to the outer integration and silences `reportUnusedParameter` for HA framework-enforced callback signatures (the "silencing strategy" called for in #57).
- Enable mypy strict mode on the outer integration (#56) — `disallow_untyped_defs`, `disallow_incomplete_defs`, `warn_return_any`, `warn_unused_ignores`. Fix the 12 errors that surfaced via targeted `cast(...)`s and return annotations.

## Root cause

`abode/config.py:34` annotated `def override(self, **kwargs: Mapping[str, pathlib.Path]):`. In PEP 484, `**kwargs: T` declares each value as `T` (and `kwargs` as `dict[str, T]`), so Pyright correctly inferred each kwarg value as `Mapping[str, Path]` and rejected a plain `Path` at the call site. The runtime implementation (`name + '_path': path`) always treated each value as a `pathlib.Path`. Mypy didn't catch it because the vendored `abode/` directory is excluded.

For #56, `disallow_untyped_defs = false` allowed real type bugs (like #57) to escape today. Flipping the flag + the three companion strict flags surfaces these without requiring Pyright.

## Test plan

- [x] `python3 -m mypy custom_components/abode_security` exits 0 with the new strict flags
- [x] `./scripts/check.sh` is green (ruff + mypy + 176 unit tests pass)
- [x] No runtime behavior change: all changes are type-only (cast assertions, signature annotations, dropped unused-ignore, tooling config)
- [x] Vendored `abode/` directory stays excluded from mypy/ruff per existing convention

## Commits

1. `fix(types): correct override() annotation in vendored config (fixes #57)`
2. `feat(types): enable mypy strict for outer integration (fixes #56)`

Fixes #57
Fixes #56
