### PR TITLE
fix(action_trigger): re-check alarm mode in _delayed_execute (fixes #53)

### DIFF
--- a/custom_components/abode_security/action_trigger.py
+++ b/custom_components/abode_security/action_trigger.py
@@ -230,7 +230,29 @@ class ActionTriggerCoordinator:
             _LOGGER.debug("Action '%s' was disabled during delay", action.name)
             return
 
-        await self._execute_action(action, triggered_by, current_mode)
+        # Re-check alarm mode: the user may have disarmed (or otherwise
+        # changed mode) during the delay window, in which case the action
+        # no longer applies and firing now would surprise the user.
+        current_mode_now = self._get_current_mode()
+        if current_mode_now is None:
+            _LOGGER.debug(
+                "Alarm panel unavailable during delay; skipping action '%s'",
+                action.name,
+            )
+            return
+        if current_mode_now not in current_action.modes:
+            _LOGGER.info(
+                "Alarm mode changed (%s -> %s) during delay; skipping action '%s'",
+                current_mode,
+                current_mode_now,
+                action.name,
+            )
+            return
+
+        # Pass the freshly fetched current_action so any edits made during the
+        # delay window (e.g. updated alarm_entity_ids) take effect — the
+        # captured `action` reference may now be stale.
+        await self._execute_action(current_action, triggered_by, current_mode_now)
 
     async def _execute_action(
         self, action: AbodeAction, triggered_by: str, current_mode: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,6 +280,7 @@ def pytest_collection_modifyitems(config, items):
         "test_unavailable_to_on_does_not_trigger",
         "test_unknown_to_on_does_not_trigger",
         "test_refire_during_pending_delay_fires_once",
+        "test_delayed_action_skipped_when_mode_changes_during_delay",
         # SocketIO reconnect (issue #2)
         "test_fires_after_threshold_connect_failures",
         "test_does_not_fire_below_threshold",

--- a/tests/test_action_trigger.py
+++ b/tests/test_action_trigger.py
@@ -780,3 +780,52 @@ class TestStateTransitionRegressions:
         assert len(service_calls) == 1
 
         await coordinator.async_stop()
+
+    async def test_delayed_action_skipped_when_mode_changes_during_delay(
+        self, hass
+    ) -> None:
+        """Disarming during a pending delay must suppress an away-only action.
+
+        Reproduces #53: `_delayed_execute` re-checked existence + enabled but
+        not the current alarm mode, so an away-only delayed action would still
+        fire after the user disarmed during the delay window. The test uses a
+        5s delay for speed; the real-world report involved a 60s delay.
+        """
+        manager = _get_manager(hass)
+        coordinator = ActionTriggerCoordinator(hass, manager)
+        await coordinator.async_start()
+
+        service_calls = []
+
+        async def mock_service(call):
+            service_calls.append(call)
+
+        hass.services.async_register("switch", "turn_on", mock_service)
+
+        await manager.async_create(
+            name="Away Only Delayed",
+            modes=["away"],
+            sensor_entity_ids=["binary_sensor.front_door"],
+            alarm_entity_ids=["switch.panic_alarm"],
+            delay_seconds=5,
+        )
+
+        hass.states.async_set("alarm_control_panel.abode_alarm", "armed_away")
+        hass.states.async_set("binary_sensor.front_door", "off")
+        await hass.async_block_till_done()
+
+        hass.states.async_set("binary_sensor.front_door", "on")
+        await hass.async_block_till_done()
+
+        assert len(coordinator._pending_delays) == 1
+
+        # User disarms during the delay.
+        hass.states.async_set("alarm_control_panel.abode_alarm", "disarmed")
+        await hass.async_block_till_done()
+
+        # Advance past the delay; the timer fires but mode no longer matches.
+        await async_fire_time_changed_and_wait(hass, timedelta(seconds=6))
+
+        assert service_calls == []
+
+        await coordinator.async_stop()


### PR DESCRIPTION
## Summary

- `_delayed_execute` now re-fetches the alarm mode after the delay and skips execution if it no longer matches the action's `modes`.
- Passes the re-fetched mode (not the captured one) into `_execute_action`, so the emitted `abode_security.action_triggered` event reflects the actual mode at fire time.
- New regression test (`test_delayed_action_skipped_when_mode_changes_during_delay`) reproduces the bug: away-only action with a 5s delay + disarm during the delay must not fire.

## Root cause

`_delayed_execute` re-checked existence and `enabled`, but not the current alarm mode. The captured `current_mode` was the mode at trigger-schedule time, so an `away`-only action scheduled with a 60s delay would still fire after the user disarmed (`away → standby`) — appearing to the user as an alarm "coming out of nowhere."

## Test plan

- [x] Added test that reproduces the bug (test fails on `main`, passes with fix)
- [x] Verified existing delay/cancel tests still pass (25/25 in `test_action_trigger.py`)
- [x] Full quality gate green: `./scripts/check.sh` → 177 passed, 0 failed
- [x] Test name added to `enabled_tests` allowlist (per CLAUDE.md gotcha)

Fixes #53
