### PR TITLE
test: remove phase-4-5 silent-skip allowlist (fixes #74)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,6 @@ Quality gates (`ruff`, `mypy`, `pyright`, `pytest`) are enforced by `.githooks/p
 
 ### Testing gotchas
 
-- **`enabled_tests` allowlist** — `tests/conftest.py` skips any test that uses the `hass` fixture unless its name is in the `enabled_tests` set (around line 30). This is a holdover from phased test rollout. Newly added tests will silently skip with `"Test infrastructure complete but test needs updates - see phase-4-5.md"` unless you add the test's name to the set. If a test runs green immediately after writing it, double-check it didn't skip.
 - **Frontend tests** — `cd frontend && npm test` runs `web-test-runner` against `frontend/src/__tests__/*.test.ts` (Playwright-backed, `@open-wc/testing`). CI runs them via `npm test` in `tests.yaml` alongside lint, format, typecheck, and build.
 
 ## Abode API quirks

--- a/features/better-development/phase-4-5.md
+++ b/features/better-development/phase-4-5.md
@@ -1,20 +1,27 @@
 # Phase 4.5: Continue Test Enablement
 
-**Status**: ✅ Complete (2025-01-16)
+**Status**: ✅ Complete — silent-skip tail fully cleared (2026-05-11, issue #74)
 **Prerequisite**: Phase 4 (Infrastructure Complete)
 
 ## Overview
 
-Phase 4 successfully completed the test infrastructure. This document outlines the work to enable the skipped tests.
+Phase 4 successfully completed the test infrastructure. Phase 4.5 progressively
+enabled the skipped tests; issue #74 finished the job by removing the
+`enabled_tests` allowlist + `pytest_collection_modifyitems` skip hook from
+`tests/conftest.py` entirely.
 
-## Final State (2025-01-16)
+## Final State (2026-05-11)
 
 - ✅ **Infrastructure**: Complete and proven working
-- ✅ **Tests enabled**: 101 passing (9 unit + 92 integration)
-- ⏳ **Tests remaining**: 125 skipped (require HA environment or mock server)
+- ✅ **Tests enabled**: 321 passing in the default `uv run pytest` run
+  (unit + integration); 0 tests skipped with the historical "Test
+  infrastructure complete but test needs updates" reason
 - ✅ **Phase 4.5.1**: Complete (config flow exception handling)
 - ✅ **Phase 4.5.2**: Complete (init exception handling)
 - ✅ **Phase 4.5.3**: Complete (platform tests with mock server)
+- ✅ **Phase 4.5 final cleanup (#74)**: removed allowlist; fixed stale
+  fixtures and assertions; the remaining mock-server-only tests are now
+  gated by `@pytest.mark.integration` instead of the name-based filter
 
 ## Challenges Identified
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,357 +20,6 @@ URL = url
 pytest_plugins = "pytest_homeassistant_custom_component"
 
 
-def pytest_collection_modifyitems(config, items):
-    """Skip tests that aren't ready yet."""
-    del config  # Unused parameter required by pytest hook
-    skip_marker = pytest.mark.skip(
-        reason="Test infrastructure complete but test needs updates - see phase-4-5.md"
-    )
-    # Tests enabled for Phase 4.5.1-4.5.2: Config flow + init tests
-    enabled_tests = {
-        # Config flow tests (Phase 4.5.1)
-        "test_one_config_allowed",
-        "test_user_flow",
-        "test_step_mfa",
-        "test_step_reauth",
-        "test_step_reauth_username_change_aborts",
-        "test_step_reauth_preserves_polling",
-        "test_user_flow_cleanup_on_success",
-        "test_user_flow_cleanup_on_login_failure",
-        "test_step_mfa_cleanup",
-        # Init tests (Phase 4.5.2)
-        "test_change_settings",
-        "test_add_unique_id",
-        "test_unload_entry",
-        "test_invalid_credentials",
-        "test_raise_config_entry_not_ready_when_offline",
-        # Platform tests with mock server (Phase 4.5.3)
-        # Binary sensor (2/2)
-        "test_binary_sensor_with_mock_server",
-        "test_binary_sensor_attributes",
-        # Cover (4/4)
-        "test_cover_entity_registry",
-        "test_cover_attributes",
-        "test_cover_open",
-        "test_cover_close",
-        # Lock (4/4)
-        "test_lock_entity_registry",
-        "test_lock_attributes",
-        "test_lock_lock",
-        "test_lock_unlock",
-        # Sensor (2/2)
-        "test_sensor_entity_registry",
-        "test_sensor_attributes",
-        # Light (7/7)
-        "test_light_entity_registry",
-        "test_light_attributes",
-        "test_light_switch_off",
-        "test_light_switch_on",
-        "test_light_set_brightness",
-        "test_light_set_color",
-        "test_light_set_color_temp",
-        # Alarm control panel (5/6) - Phase 4.5.3
-        # Note: test_alarm_state_unknown removed - edge case difficult to test in integration context
-        "test_alarm_entity_registry",
-        "test_alarm_attributes",
-        "test_alarm_arm_away",
-        "test_alarm_arm_home",
-        "test_alarm_disarm",
-        # Camera (5/5) - Phase 4.5.3
-        "test_camera_entity_registry",
-        "test_camera_attributes",
-        "test_camera_capture_image",
-        "test_camera_on",
-        "test_camera_off",
-        # Switch (21/21) - Phase 4.5.3
-        "test_switch_entity_registry",
-        "test_switch_attributes",
-        "test_switch_on",
-        "test_switch_off",
-        "test_automation_attributes",
-        "test_turn_automation_off",
-        "test_turn_automation_on",
-        "test_trigger_automation",
-        "test_manual_alarm_switch_attributes",
-        "test_manual_alarm_switch_turn_on",
-        "test_test_mode_switch_attributes",
-        "test_test_mode_switch_initial_status_on",
-        "test_test_mode_switch_initial_status_off",
-        "test_test_mode_switch_turn_on",
-        "test_test_mode_switch_turn_off",
-        "test_trigger_alarm_service",
-        # Services null-safety regression tests (issue #70)
-        "test_trigger_alarm_no_alarm_device_logs_and_returns",
-        "test_trigger_alarm_with_alarm_device_calls_through",
-        # Switch platform null-safety regression tests (issue #70)
-        "test_setup_entry_skips_alarm_attached_when_no_alarm",
-        "test_setup_entry_adds_alarm_attached_when_alarm_present",
-        # Alarm control panel null-safety regression tests (issue #70)
-        "test_setup_entry_skips_panel_when_no_alarm",
-        "test_setup_entry_adds_panel_when_alarm_present",
-        "test_acknowledge_alarm_service",
-        "test_dismiss_alarm_service",
-        "test_abode_switch_error_handling",
-        "test_automation_switch_error_handling",
-        "test_automation_trigger_error_handling",
-        # CMS Settings Switches (42/42) - Phase 4.5.3
-        # Monitoring Active (7)
-        "test_monitoring_active_entity_registry",
-        "test_monitoring_active_attributes",
-        "test_monitoring_active_initial_status_on",
-        "test_monitoring_active_initial_status_off",
-        "test_monitoring_active_turn_on",
-        "test_monitoring_active_turn_off",
-        "test_monitoring_active_error_handling",
-        # Send Media (7)
-        "test_send_media_entity_registry",
-        "test_send_media_attributes",
-        "test_send_media_initial_status_on",
-        "test_send_media_initial_status_off",
-        "test_send_media_turn_on",
-        "test_send_media_turn_off",
-        "test_send_media_error_handling",
-        # Dispatch Without Verification (7)
-        "test_dispatch_without_verification_entity_registry",
-        "test_dispatch_without_verification_attributes",
-        "test_dispatch_without_verification_initial_status_on",
-        "test_dispatch_without_verification_initial_status_off",
-        "test_dispatch_without_verification_turn_on",
-        "test_dispatch_without_verification_turn_off",
-        "test_dispatch_without_verification_error_handling",
-        # Dispatch Police (7)
-        "test_dispatch_police_entity_registry",
-        "test_dispatch_police_attributes",
-        "test_dispatch_police_initial_status_on",
-        "test_dispatch_police_initial_status_off",
-        "test_dispatch_police_turn_on",
-        "test_dispatch_police_turn_off",
-        "test_dispatch_police_error_handling",
-        # Dispatch Fire (7)
-        "test_dispatch_fire_entity_registry",
-        "test_dispatch_fire_attributes",
-        "test_dispatch_fire_initial_status_on",
-        "test_dispatch_fire_initial_status_off",
-        "test_dispatch_fire_turn_on",
-        "test_dispatch_fire_turn_off",
-        "test_dispatch_fire_error_handling",
-        # Dispatch Medical (7)
-        "test_dispatch_medical_entity_registry",
-        "test_dispatch_medical_attributes",
-        "test_dispatch_medical_initial_status_on",
-        "test_dispatch_medical_initial_status_off",
-        "test_dispatch_medical_turn_on",
-        "test_dispatch_medical_turn_off",
-        "test_dispatch_medical_error_handling",
-        # Action Manager tests (Phase 1 - Dashboard Configuration)
-        "test_action_creation_defaults",
-        "test_action_creation_all_fields",
-        "test_action_to_dict",
-        "test_action_to_dict_with_datetime",
-        "test_action_from_dict",
-        "test_action_from_dict_with_datetime_string",
-        "test_action_round_trip",
-        # ActionStore tests (Phase 1 - Dashboard Configuration)
-        "test_store_init",
-        "test_store_add_and_get",
-        "test_store_persistence",
-        "test_store_remove",
-        "test_store_remove_not_found",
-        "test_store_get_all",
-        # ActionManager tests - Sub-Phase A (Phase 2 - Dashboard Configuration)
-        "test_manager_create_valid",
-        "test_manager_create_empty_name",
-        "test_manager_create_whitespace_name",
-        "test_manager_create_name_too_long",
-        "test_manager_create_empty_modes",
-        "test_manager_create_invalid_mode",
-        "test_manager_create_empty_sensors",
-        "test_manager_create_empty_alarms",
-        "test_manager_create_invalid_delay",
-        "test_manager_create_negative_delay",
-        "test_manager_create_missing_entity_warning",
-        "test_manager_get",
-        "test_manager_get_not_found",
-        "test_manager_get_all",
-        "test_manager_update",
-        "test_manager_update_partial",
-        "test_manager_update_not_found",
-        "test_manager_update_validation_error",
-        "test_manager_delete",
-        "test_manager_delete_not_found",
-        # ActionManager tests - Sub-Phase B (Phase 2 - Dashboard Configuration)
-        "test_manager_get_by_mode",
-        "test_manager_get_by_mode_excludes_disabled",
-        "test_manager_get_enabled",
-        "test_manager_toggle",
-        "test_manager_toggle_not_found",
-        "test_manager_record_trigger",
-        "test_manager_record_trigger_increments",
-        "test_manager_record_trigger_not_found",
-        # WebSocket API tests - Sub-Phase A (Phase 3 - Dashboard Configuration)
-        "test_ws_actions_list_empty",
-        "test_ws_actions_list_with_data",
-        "test_ws_actions_get",
-        "test_ws_actions_get_not_found",
-        "test_ws_actions_create",
-        "test_ws_actions_create_with_delay",
-        "test_ws_actions_create_validation_error",
-        "test_ws_actions_create_invalid_mode_schema",
-        "test_ws_actions_create_name_too_long",
-        "test_ws_actions_create_too_many_modes",
-        "test_ws_actions_create_too_many_sensors",
-        "test_ws_actions_create_too_many_alarms",
-        "test_ws_actions_create_rejects_bool_delay",
-        "test_ws_actions_update",
-        "test_ws_actions_update_not_found",
-        "test_ws_actions_update_validation_error",
-        "test_ws_actions_update_name_too_long",
-        "test_ws_actions_delete",
-        "test_ws_actions_delete_not_found",
-        "test_ws_actions_toggle",
-        "test_ws_actions_toggle_not_found",
-        "test_ws_actions_test",
-        "test_ws_actions_test_not_found",
-        "test_ws_actions_test_multiple_alarms",
-        "test_ws_actions_list_no_admin_required",
-        "test_ws_actions_get_no_admin_required",
-        "test_ws_actions_list_not_ready",
-        # WebSocket API tests - Sub-Phase B (Phase 3 - Dashboard Configuration)
-        "test_ws_modes_list",
-        "test_ws_modes_list_with_active_mode",
-        "test_ws_modes_list_disarmed",
-        "test_ws_modes_list_with_action_count",
-        "test_ws_modes_list_has_metadata",
-        "test_ws_modes_set_home",
-        "test_ws_modes_set_away",
-        "test_ws_modes_set_standby",
-        "test_ws_modes_set_invalid_mode",
-        "test_ws_modes_set_no_panel",
-        "test_ws_modes_set_finds_renamed_entity_via_registry",
-        "test_ws_modes_list_finds_renamed_entity_via_registry",
-        "test_ws_entities_sensors_empty",
-        "test_ws_entities_sensors_grouped_by_device_class",
-        "test_ws_entities_sensors_includes_state",
-        "test_ws_entities_sensors_no_device_class",
-        "test_ws_entities_alarms_empty",
-        "test_ws_entities_alarms_filters_abode_alarms",
-        "test_ws_entities_alarms_includes_type",
-        # WebSocket API tests - Sub-Phase C (Phase 3 - Dashboard Configuration)
-        "test_ws_config_get",
-        "test_ws_config_set",
-        "test_ws_config_set_min_value",
-        "test_ws_config_set_max_value",
-        "test_ws_config_set_below_min",
-        "test_ws_config_set_above_max",
-        "test_ws_config_set_no_fields",
-        "test_ws_config_persistence",
-        "test_ws_config_get_not_ready",
-        "test_ws_config_set_not_ready",
-        # ActionTriggerCoordinator tests (Phase 4 - Dashboard Configuration)
-        # Sub-Phase A: Coordinator Core
-        "test_coordinator_init",
-        "test_coordinator_start_stop",
-        "test_coordinator_get_mode_standby",
-        "test_coordinator_get_mode_home",
-        "test_coordinator_get_mode_away",
-        "test_coordinator_get_mode_no_panel",
-        # Sub-Phase B: State Change Handling
-        "test_coordinator_ignores_non_binary_sensor",
-        "test_coordinator_ignores_off_state",
-        "test_coordinator_matches_sensor_and_mode",
-        "test_coordinator_no_match_wrong_mode",
-        "test_coordinator_no_match_wrong_sensor",
-        "test_coordinator_debounce",
-        # Sub-Phase C: Action Execution
-        "test_coordinator_triggers_alarm_service",
-        "test_coordinator_fires_event",
-        "test_coordinator_multiple_actions",
-        "test_coordinator_disabled_action_not_triggered",
-        "test_coordinator_delayed_action",
-        "test_coordinator_delayed_action_cancelled_on_delete",
-        "test_coordinator_delayed_action_cancelled_on_disable",
-        "test_coordinator_multi_alarm_continues_on_failure",
-        "test_coordinator_cancel_pending_for_action",
-        # State-transition regressions
-        "test_unavailable_to_on_does_not_trigger",
-        "test_unknown_to_on_does_not_trigger",
-        "test_refire_during_pending_delay_fires_once",
-        "test_delayed_action_skipped_when_mode_changes_during_delay",
-        # SocketIO reconnect (issue #2)
-        "test_fires_after_threshold_connect_failures",
-        "test_does_not_fire_below_threshold",
-        "test_resets_after_successful_connect_then_refires",
-        "test_websocket_connected_resets_counter",
-        "test_cookie_cleared_before_subsequent_iterations",
-        "test_seeds_only_on_first_started",
-        "test_persistent_disconnect_handler_updates_client_status",
-        "test_connection_recovered_handler_updates_client_status",
-        # Client session recreation (issue #3)
-        "test_recreate_waits_for_in_flight_request",
-        "test_two_concurrent_recreates_run_one_login_at_a_time",
-        "test_failure_counter_reset_after_recreate",
-        "test_hung_request_finally_skipped_after_generation_bump",
-        # Client cleanup drain (issue #14)
-        "test_cleanup_waits_for_in_flight_request",
-        "test_cleanup_drain_timeout_forces_close",
-        "test_send_request_after_cleanup_raises",
-        "test_cleanup_called_twice_closes_session_only_once",
-        "test_cleanup_waits_for_concurrent_recreate",
-        "test_parked_request_raises_when_cleanup_wakes_it",
-        "test_recreate_after_cleanup_does_not_allocate_session",
-        "test_second_cleanup_does_not_return_until_first_finishes",
-        "test_cleanup_logs_and_swallows_aiohttp_close_error",
-        # Test fixture hygiene — TCPConnector stub (issue #15)
-        "test_recreate_session_does_not_construct_real_connector",
-        # Switch unique_id regression guards (issue #7)
-        "test_test_mode_switch_unique_id_preserved",
-        "test_monitoring_active_switch_unique_id_preserved",
-        "test_send_media_switch_unique_id_preserved",
-        "test_dispatch_without_verification_switch_unique_id_preserved",
-        "test_dispatch_police_switch_unique_id_preserved",
-        "test_dispatch_fire_switch_unique_id_preserved",
-        "test_dispatch_medical_switch_unique_id_preserved",
-        "test_test_mode_switch_name_and_icon",
-        "test_test_mode_switch_uses_test_mode_supported_flag",
-        "test_cms_setting_base_default_support_flag",
-        "test_cms_switches_table_covers_all_legacy_entities",
-        # Alarm-attached entity base (issue #8)
-        "test_alarm_attached_device_info_consistent_manual_alarm",
-        "test_alarm_attached_device_info_consistent_cms",
-        "test_alarm_attached_device_info_consistent_test_mode",
-        # Debug-log redaction (issue #49)
-        "test_login_response_redacts_token_and_user_pii",
-        "test_oauth_nested_dict_is_redacted",
-        "test_redact_is_case_insensitive",
-        "test_redact_walks_lists",
-        "test_redact_passes_through_primitives",
-        "test_redact_does_not_mutate_input",
-        "test_redact_text_handles_json_payload",
-        "test_redact_text_returns_summary_for_non_json",
-        "test_login_debug_log_redacts_token",
-        # Diagnostics PII redaction (issue #50)
-        "test_unique_id_is_redacted",
-        "test_email_does_not_appear_anywhere_in_payload",
-        # ActionStore load resilience (issue #54)
-        "test_load_skips_record_missing_required_key",
-        "test_load_skips_record_with_wrong_type",
-        "test_load_empty_file_no_regression",
-        "test_load_non_dict_root",
-        "test_load_non_dict_actions",
-        "test_load_duplicate_ids",
-        "test_load_clears_repair_issue_on_clean_reload",
-        "test_load_invalid_delay_seconds",
-        "test_load_invalid_mode_value",
-        "test_load_invalid_last_triggered",
-        "test_load_last_triggered_wrong_type",
-        "test_load_missing_optional_keys_uses_defaults",
-    }
-    # Skip tests with hass fixture except enabled tests
-    for item in items:
-        if "hass" in item.fixturenames and item.name not in enabled_tests:
-            item.add_marker(skip_marker)
-
-
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable custom integrations for all tests."""
@@ -391,7 +40,33 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 def mock_abode() -> Generator[Mock]:
     """Provide a mock Abode client."""
     mock_client = Mock()
-    mock_client.get_alarm = AsyncMock(return_value=Mock())
+    # The alarm Mock needs concrete (JSON-serializable) values for every
+    # attribute touched during entity setup, otherwise the entity_registry's
+    # serialization step fails on Mock objects (TypeError "Type is not JSON
+    # serializable: Mock") and tears down the entire test.
+    # - `id`/`name`/`type` flow into `device_info` and the device-slug part of
+    #   `entity_id` (tests in test_entity_lifecycle.py expect `test_alarm_*`).
+    # - `uuid` is `_attr_unique_id` for AbodeDevice.
+    # - `battery`/`battery_low`/`is_cellular`/`is_standby`/`is_away`/`is_home`/
+    #   `no_response` are accessed by `_sync_attrs` on AbodeAlarm/AbodeDevice.
+    mock_alarm = Mock()
+    mock_alarm.id = "test_alarm_id"
+    mock_alarm.uuid = "test_alarm_uuid"
+    mock_alarm.name = "Test Alarm"
+    mock_alarm.type = "alarm"
+    mock_alarm.battery = "ok"
+    mock_alarm.battery_low = False
+    mock_alarm.is_cellular = False
+    mock_alarm.is_standby = True
+    mock_alarm.is_away = False
+    mock_alarm.is_home = False
+    mock_alarm.no_response = False
+    mock_alarm.trigger_manual_alarm = AsyncMock(return_value=None)
+    mock_alarm.set_standby = AsyncMock(return_value=None)
+    mock_alarm.set_home = AsyncMock(return_value=None)
+    mock_alarm.set_away = AsyncMock(return_value=None)
+    # `get_alarm` is sync in production (client.py:758) — use Mock, not AsyncMock.
+    mock_client.get_alarm = Mock(return_value=mock_alarm)
     mock_client.get_devices = AsyncMock(return_value=[])
     mock_client.get_automations = AsyncMock(return_value=[])
     mock_client.get_test_mode = AsyncMock(return_value=False)

--- a/tests/fixtures/automation.json
+++ b/tests/fixtures/automation.json
@@ -1,35 +1,37 @@
-{
-  "name": "Test Automation",
-  "enabled": "True",
-  "version": 2,
-  "id": "47fae27488f74f55b964a81a066c3a01",
-  "subType": "",
-  "actions": [
-    {
-      "directive": {
-        "trait": "panel.traits.panelMode",
-        "name": "panel.directives.arm",
-        "state": {
-          "panelMode": "AWAY"
-        }
-      }
-    }
-  ],
-  "conditions": {},
-  "triggers": {
-    "operator": "OR",
-    "expressions": [
+[
+  {
+    "name": "Test Automation",
+    "enabled": "True",
+    "version": 2,
+    "id": "47fae27488f74f55b964a81a066c3a01",
+    "subType": "",
+    "actions": [
       {
-        "mobileDevices": ["89381", "658"],
-        "property": {
-          "trait": "mobile.traits.location",
-          "name": "location",
-          "rule": {
-            "location": "31675",
-            "equalTo": "LAST_OUT"
+        "directive": {
+          "trait": "panel.traits.panelMode",
+          "name": "panel.directives.arm",
+          "state": {
+            "panelMode": "AWAY"
           }
         }
       }
-    ]
+    ],
+    "conditions": {},
+    "triggers": {
+      "operator": "OR",
+      "expressions": [
+        {
+          "mobileDevices": ["89381", "658"],
+          "property": {
+            "trait": "mobile.traits.location",
+            "name": "location",
+            "rule": {
+              "location": "31675",
+              "equalTo": "LAST_OUT"
+            }
+          }
+        }
+      ]
+    }
   }
-}
+]

--- a/tests/test_async_await_verification.py
+++ b/tests/test_async_await_verification.py
@@ -7,6 +7,7 @@ without requiring a full Home Assistant instance setup.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import sys
 from pathlib import Path
@@ -22,29 +23,24 @@ class TestAsyncAwaitPatterns:
     """Test async/await patterns in the integration."""
 
     def test_service_handlers_have_correct_types(self) -> None:
-        """Verify service handler functions have correct async/sync types."""
+        """Verify service handler functions are async coroutine functions.
+
+        HA's `async_register` accepts either sync or async handlers, but the
+        integration's convention is that every service handler is `async def`
+        so they can await Abode client methods uniformly. Regression guard.
+        """
         from custom_components.abode_security import services
 
-        # Handlers that should be async (contain await)
         async_handlers = [
             ("_change_setting", services._change_setting),
             ("_trigger_alarm_handler", services._trigger_alarm_handler),
+            ("_capture_image", services._capture_image),
+            ("_trigger_automation", services._trigger_automation),
         ]
 
         for name, func in async_handlers:
             assert inspect.iscoroutinefunction(func), (
                 f"{name} should be async def but is {type(func)}"
-            )
-
-        # Handlers that should be sync (no await)
-        sync_handlers = [
-            ("_capture_image", services._capture_image),
-            ("_trigger_automation", services._trigger_automation),
-        ]
-
-        for name, func in sync_handlers:
-            assert not inspect.iscoroutinefunction(func), (
-                f"{name} should be sync def but is async"
             )
 
     def test_entity_lifecycle_methods_are_async(self) -> None:
@@ -145,7 +141,13 @@ class TestAsyncAwaitPatterns:
             )
 
     def test_timeout_protection_on_executor_jobs(self) -> None:
-        """Verify executor jobs are protected with asyncio.wait_for()."""
+        """Verify executor jobs are protected with `asyncio.wait_for`.
+
+        Earlier versions inlined `asyncio.wait_for(...)` at each call site
+        (hence the original ≥4 count). The current code factors this into
+        `_run_executor_with_timeout`, so the regression guard is now "the
+        helper exists and uses wait_for with a timeout".
+        """
         entity_file = (
             Path(__file__).parent.parent
             / "custom_components"
@@ -154,13 +156,12 @@ class TestAsyncAwaitPatterns:
         )
         content = entity_file.read_text()
 
-        # Count asyncio.wait_for usage
-        wait_for_count = content.count("asyncio.wait_for(")
-        assert wait_for_count >= 4, (
-            f"Expected at least 4 asyncio.wait_for calls in entity.py, found {wait_for_count}"
+        assert "async def _run_executor_with_timeout(" in content, (
+            "entity.py should define the _run_executor_with_timeout helper"
         )
-
-        # Verify timeout parameter
+        assert "asyncio.wait_for(" in content, (
+            "entity.py should use asyncio.wait_for for timeout protection"
+        )
         assert "timeout=" in content, "asyncio.wait_for should have timeout parameter"
 
     def test_service_handler_factory_creates_async_handler(self) -> None:
@@ -306,8 +307,8 @@ class TestAsyncAwaitSemantics:
             pass  # May fail due to mock, but should be awaitable
 
     @pytest.mark.asyncio
-    async def test_capture_image_handler_not_awaitable(self) -> None:
-        """Verify _capture_image handler is NOT async."""
+    async def test_capture_image_handler_is_awaitable(self) -> None:
+        """Verify `_capture_image` is async (matches the rest of the handlers)."""
         from custom_components.abode_security.services import _capture_image
 
         mock_call = MagicMock()
@@ -315,16 +316,14 @@ class TestAsyncAwaitSemantics:
         mock_call.hass = MagicMock()
         mock_call.hass.config_entries.async_entries.return_value = []
 
-        # Should NOT be a coroutine
-        result = _capture_image(mock_call)
-        assert not inspect.iscoroutine(result), (
-            "_capture_image should not return a coroutine"
-        )
-        assert result is None, "_capture_image should return None"
+        coro = _capture_image(mock_call)
+        assert inspect.iscoroutine(coro), "_capture_image should return a coroutine"
+        with contextlib.suppress(Exception):
+            await coro  # may fail on mocks, but must be awaitable
 
     @pytest.mark.asyncio
-    async def test_trigger_automation_handler_not_awaitable(self) -> None:
-        """Verify _trigger_automation handler is NOT async."""
+    async def test_trigger_automation_handler_is_awaitable(self) -> None:
+        """Verify `_trigger_automation` is async (matches the rest of the handlers)."""
         from custom_components.abode_security.services import _trigger_automation
 
         mock_call = MagicMock()
@@ -332,12 +331,12 @@ class TestAsyncAwaitSemantics:
         mock_call.hass = MagicMock()
         mock_call.hass.config_entries.async_entries.return_value = []
 
-        # Should NOT be a coroutine
-        result = _trigger_automation(mock_call)
-        assert not inspect.iscoroutine(result), (
-            "_trigger_automation should not return a coroutine"
+        coro = _trigger_automation(mock_call)
+        assert inspect.iscoroutine(coro), (
+            "_trigger_automation should return a coroutine"
         )
-        assert result is None, "_trigger_automation should return None"
+        with contextlib.suppress(Exception):
+            await coro
 
     @pytest.mark.asyncio
     async def test_factory_handler_is_awaitable(self) -> None:

--- a/tests/test_async_static_analysis.py
+++ b/tests/test_async_static_analysis.py
@@ -43,6 +43,14 @@ class AsyncAwaitStaticAnalyzer:
                             return True
         return False
 
+    def function_has_docstring(self, func_name: str) -> bool:
+        """Check if a function has a docstring."""
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):  # noqa: SIM102
+                if node.name == func_name and ast.get_docstring(node) is not None:
+                    return True
+        return False
+
     def count_await_statements(self) -> int:
         """Count total await statements in the code."""
         count = 0
@@ -163,47 +171,38 @@ class TestAsyncAwaitStaticPatterns:
         return path.read_text()
 
     def test_service_handler_signatures(self, services_file: str) -> None:
-        """Verify service handler function signatures are correct."""
+        """Verify every service handler is declared `async def`.
+
+        Convention: all handlers are async so they can await Abode client
+        methods uniformly. Regression guard against accidental sync drift.
+        """
         analyzer = AsyncAwaitStaticAnalyzer(services_file, "services.py")
         async_funcs = analyzer.find_async_functions()
 
-        # These should be async
-        assert async_funcs.get("_change_setting") is True, (
-            "_change_setting should be async def"
-        )
-        assert async_funcs.get("_trigger_alarm_handler") is True, (
-            "_trigger_alarm_handler should be async def"
-        )
-
-        # These should be sync
-        assert async_funcs.get("_capture_image") is False, (
-            "_capture_image should be sync def"
-        )
-        assert async_funcs.get("_trigger_automation") is False, (
-            "_trigger_automation should be sync def"
-        )
+        for name in (
+            "_change_setting",
+            "_trigger_alarm_handler",
+            "_capture_image",
+            "_trigger_automation",
+        ):
+            assert async_funcs.get(name) is True, f"{name} should be async def"
 
     def test_service_handlers_have_correct_await_usage(
         self, services_file: str
     ) -> None:
-        """Verify service handlers use await correctly."""
+        """Verify handlers that touch the Abode client actually `await` it.
+
+        `_capture_image` and `_trigger_automation` are async by convention
+        (handlers are uniformly async, see `test_service_handler_signatures`)
+        but dispatch via the sync `async_dispatcher_send` rather than awaiting
+        the client, so they aren't checked here.
+        """
         analyzer = AsyncAwaitStaticAnalyzer(services_file, "services.py")
 
-        # Async handlers should have await
-        assert analyzer.function_contains_await("_change_setting"), (
-            "_change_setting should contain await"
-        )
-        assert analyzer.function_contains_await("_trigger_alarm_handler"), (
-            "_trigger_alarm_handler should contain await"
-        )
-
-        # Sync handlers should not have await
-        assert not analyzer.function_contains_await("_capture_image"), (
-            "_capture_image should not contain await"
-        )
-        assert not analyzer.function_contains_await("_trigger_automation"), (
-            "_trigger_automation should not contain await"
-        )
+        for name in ("_change_setting", "_trigger_alarm_handler"):
+            assert analyzer.function_contains_await(name), (
+                f"{name} should contain `await` on its Abode client call"
+            )
 
     def test_factory_handler_is_async(self, services_file: str) -> None:
         """Verify service handler factory creates async handler."""
@@ -235,13 +234,21 @@ class TestAsyncAwaitStaticPatterns:
             )
 
     def test_timeout_protection_in_entity(self, entity_file: str) -> None:
-        """Verify executor jobs have timeout protection."""
+        """Verify executor jobs have timeout protection via a helper.
+
+        Earlier versions inlined `asyncio.wait_for(...)` at each call site
+        (≥4 occurrences). The current code factors this into
+        `_run_executor_with_timeout`, so the regression guard now checks that
+        the helper exists and at least one `wait_for` call remains.
+        """
         analyzer = AsyncAwaitStaticAnalyzer(entity_file, "entity.py")
         wait_for_calls = analyzer.find_wait_for_calls()
 
-        # Should have multiple asyncio.wait_for calls
-        assert len(wait_for_calls) >= 4, (
-            f"Entity should have at least 4 asyncio.wait_for calls, "
+        assert "_run_executor_with_timeout" in entity_file, (
+            "entity.py should define the _run_executor_with_timeout helper"
+        )
+        assert len(wait_for_calls) >= 1, (
+            "Entity should keep at least one asyncio.wait_for call, "
             f"found {len(wait_for_calls)}"
         )
 
@@ -311,11 +318,11 @@ class TestAsyncAwaitStaticPatterns:
         assert "hass.loop" not in init_file, "__init__.py should not use hass.loop"
 
     def test_timeout_protection_pattern(self, entity_file: str) -> None:
-        """Verify timeout protection pattern with try/except."""
-        # Count asyncio.wait_for calls
+        """Verify timeout protection pattern with try/except via the helper."""
         wait_for_count = entity_file.count("asyncio.wait_for(")
-        assert wait_for_count >= 4, (
-            f"Expected at least 4 asyncio.wait_for calls, found {wait_for_count}"
+        assert wait_for_count >= 1, (
+            "Expected at least one asyncio.wait_for call in entity.py, "
+            f"found {wait_for_count}"
         )
 
         # Should have timeout parameter
@@ -329,19 +336,24 @@ class TestAsyncAwaitDocumentation:
     """Test that async/await patterns are documented."""
 
     def test_service_handlers_have_docstrings(self) -> None:
-        """Verify service handlers have docstring explanations."""
+        """Verify service handlers each carry a docstring."""
         services_file = (
             Path(__file__).parent.parent
             / "custom_components"
             / "abode_security"
             / "services.py"
         )
-        content = services_file.read_text()
+        analyzer = AsyncAwaitStaticAnalyzer(services_file.read_text(), "services.py")
 
-        # Check for docstring on _capture_image
-        assert "dispatcher_send()" in content and "sync" in content.lower(), (
-            "Service handlers should document why they are sync/async"
-        )
+        for handler in (
+            "_change_setting",
+            "_trigger_alarm_handler",
+            "_capture_image",
+            "_trigger_automation",
+        ):
+            assert analyzer.function_has_docstring(handler), (
+                f"{handler} should have a docstring"
+            )
 
     def test_async_patterns_documented(self) -> None:
         """Verify async patterns are documented in code."""

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -28,12 +28,20 @@ from .common import setup_platform
 
 
 async def test_entity_registry(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aiohttp_mock,  # noqa: ARG001
 ) -> None:
-    """Tests that the devices are registered in the entity registry."""
+    """Tests that the devices are registered in the entity registry.
+
+    Uses `aiohttp_mock` so the real `Client` can run through login/devices
+    fetch against canned fixtures (`tests/fixtures/devices.json`) — the
+    `front_door` sensor and its unique_id come from that fixture.
+    """
     await setup_platform(hass, BINARY_SENSOR_DOMAIN)
 
     entry = entity_registry.async_get("binary_sensor.front_door")
+    assert entry is not None
     assert entry.unique_id == "2834013428b6035fba7d4054aa7b25a3"
 
 

--- a/tests/test_conftest_no_allowlist.py
+++ b/tests/test_conftest_no_allowlist.py
@@ -1,0 +1,29 @@
+"""Regression test for issue #74: the phase-4.5 allowlist must not return.
+
+`tests/conftest.py` used to carry an `enabled_tests` set plus a
+`pytest_collection_modifyitems` hook that silently skipped any test using the
+`hass` fixture (transitively, in practice every test) unless its name was in
+the allowlist. That made the suite report ~119 silent skips and meant
+newly-added tests could silently skip without any signal. Issue #74 removed
+the mechanism; this test guards against accidental reintroduction.
+"""
+
+from pathlib import Path
+
+
+def test_conftest_has_no_phase45_allowlist() -> None:
+    """`tests/conftest.py` must not contain the phase-4-5 skip allowlist."""
+    content = Path(__file__).parent.joinpath("conftest.py").read_text()
+    # Anchor on the specific token shapes that defined the mechanism, not bare
+    # substrings — that way a future commit can mention the historical name in
+    # a comment without tripping this guard.
+    assert "enabled_tests = {" not in content, (
+        "Issue #74: the `enabled_tests` allowlist must not be reintroduced. "
+        "If you need to skip a test, mark it explicitly with @pytest.mark.skip."
+    )
+    assert "def pytest_collection_modifyitems" not in content, (
+        "Issue #74: the collection-modifying skip hook must not be reintroduced."
+    )
+    assert "Test infrastructure complete but test needs updates" not in content, (
+        "Issue #74: the phase-4-5.md skip-reason text must not be reintroduced."
+    )

--- a/tests/test_e2e_scenarios.py
+++ b/tests/test_e2e_scenarios.py
@@ -42,7 +42,7 @@ class TestFullSetupWorkflow:
         # Step 2: Integration is set up
         with (
             patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-            patch("abode.event_controller.sio"),
+            patch("custom_components.abode_security.abode.event_controller.sio"),
         ):
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
@@ -63,7 +63,14 @@ class TestFullSetupWorkflow:
     async def test_integration_recovers_from_temporary_failure(
         self, hass: HomeAssistant
     ) -> None:
-        """Test that integration recovers from temporary API failure."""
+        """Test that integration recovers from temporary API failure.
+
+        `__init__.py` maps `AbodeException` and `aiohttp.ClientError` to
+        `ConfigEntryNotReady` (→ SETUP_RETRY). Bare `Exception` is unhandled
+        and lands in SETUP_ERROR, so simulate a recoverable error here.
+        """
+        import aiohttp
+
         mock_entry = MockConfigEntry(
             domain=DOMAIN,
             data={
@@ -74,35 +81,61 @@ class TestFullSetupWorkflow:
         )
         mock_entry.add_to_hass(hass)
 
-        # First attempt fails
+        # First attempt fails with a recoverable error.
         with patch(
-            "custom_components.abode_security.Abode",
-            side_effect=Exception("Temporary API failure"),
+            "custom_components.abode_security.abode.client.Client",
+            side_effect=aiohttp.ClientConnectionError("Temporary API failure"),
         ):
             with (
                 patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-                patch("abode.event_controller.sio"),
+                patch("custom_components.abode_security.abode.event_controller.sio"),
             ):
                 await async_setup_component(hass, DOMAIN, {})
 
             await hass.async_block_till_done()
-            # Should be in setup retry state
             assert mock_entry.state is ConfigEntryState.SETUP_RETRY
 
-        # Second attempt succeeds
+        # Second attempt succeeds. Async methods (get_devices/get_automations/
+        # logout) must be AsyncMock; get_alarm is sync (client.py:758). The
+        # alarm Mock needs concrete `id`/`name`/`type` so the entity_registry
+        # can JSON-serialize the resulting device entry on teardown.
+        # NB: Mock() interprets `name=` as its own debug name, not the
+        # attribute `.name`. Set attributes after construction.
+        working_alarm = Mock(
+            id="recovered_alarm_id",
+            uuid="recovered_alarm_uuid",
+            type="alarm",
+            battery="ok",
+            battery_low=False,
+            is_cellular=False,
+            is_standby=True,
+            is_away=False,
+            is_home=False,
+            no_response=False,
+        )
+        working_alarm.name = "Recovered Alarm"
+        # `__init__.py` short-circuits on truthy `_token` / `_devices` /
+        # `_automations`, and `Mock()` auto-attributes are truthy, so the
+        # implicit login/get_devices/get_automations calls are intentionally
+        # skipped by this mock — we only care that the reload path succeeds.
+        working_client = Mock(
+            get_alarm=Mock(return_value=working_alarm),
+            get_devices=AsyncMock(return_value=[]),
+            get_automations=AsyncMock(return_value=[]),
+            events=Mock(),
+            logout=AsyncMock(),
+            cleanup=AsyncMock(),
+            _async_initialize=AsyncMock(),
+            get_test_mode=AsyncMock(return_value=False),
+            get_cms_settings=AsyncMock(return_value={}),
+        )
         with patch(
-            "custom_components.abode_security.Abode",
-            return_value=Mock(
-                get_alarm=Mock(return_value=Mock()),
-                get_devices=Mock(return_value=[]),
-                get_automations=Mock(return_value=[]),
-                events=Mock(),
-                logout=Mock(),
-            ),
+            "custom_components.abode_security.abode.client.Client",
+            return_value=working_client,
         ):
             with (
                 patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-                patch("abode.event_controller.sio"),
+                patch("custom_components.abode_security.abode.event_controller.sio"),
             ):
                 await hass.config_entries.async_reload(mock_entry.entry_id)
             await hass.async_block_till_done()
@@ -119,10 +152,14 @@ class TestFullSetupWorkflow:
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
-        # Initial polling stats
-        stats_before = abode_system.smart_polling.stats
+        # Snapshot the counters — `stats` returns a live reference, so we
+        # can't compare object-to-object; record the scalar values up front.
+        update_count_before = abode_system.smart_polling.stats.update_count
+        error_count_before = abode_system.smart_polling.stats.error_count
 
         # Simulate multiple successful updates (good performance)
         for _ in range(5):
@@ -132,13 +169,12 @@ class TestFullSetupWorkflow:
         for _ in range(3):
             abode_system.smart_polling.record_error()
 
-        # Get updated stats
-        stats_after = abode_system.smart_polling.stats
+        update_count_after = abode_system.smart_polling.stats.update_count
+        error_count_after = abode_system.smart_polling.stats.error_count
         interval_after = abode_system.smart_polling.get_optimal_interval()
 
-        # Verify stats were tracked
-        assert stats_after.update_count > stats_before.update_count
-        assert stats_after.error_count > stats_before.error_count
+        assert update_count_after > update_count_before
+        assert error_count_after > error_count_before
 
         # Verify polling interval is still within bounds
         assert 15 <= interval_after <= 120
@@ -152,11 +188,14 @@ class TestFullSetupWorkflow:
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
-        # Set filter to only allow critical events
+        # Narrow the filter list directly (EventFilter has no setter; the
+        # production code path is to pass the list at construction time).
         critical_events = ["alarm_state_change", "test_mode_change"]
-        abode_system.event_filter.set_filter(critical_events)
+        abode_system.event_filter.filter_types = critical_events
 
         # Simulate receiving various events
         events_received = [
@@ -177,10 +216,12 @@ class TestFullSetupWorkflow:
         # Only 2 out of 6 events should be processed (alarm_state_change, test_mode_change)
         assert processed_count == 2
 
-        # Verify filtering stats
+        # Verify filtering stats — `get_stats()` returns keys
+        # filtered/allowed/total (see EventFilter in models.py).
         stats = abode_system.event_filter.get_stats()
-        assert stats["total_checks"] == 6
-        assert stats["filtered_count"] == 4
+        assert stats["total"] == 6
+        assert stats["filtered"] == 4
+        assert stats["allowed"] == 2
 
 
 class TestBatchOperationsWorkflow:
@@ -276,21 +317,24 @@ class TestConfigurationPresets:
                 CONF_USERNAME: "user@example.com",
                 CONF_PASSWORD: "password123",
                 CONF_POLLING: True,
-                CONF_POLLING_INTERVAL: aggressive_preset["interval"],
+                CONF_POLLING_INTERVAL: aggressive_preset[CONF_POLLING_INTERVAL],
             },
         )
         mock_entry.add_to_hass(hass)
 
         with (
             patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-            patch("abode.event_controller.sio"),
+            patch("custom_components.abode_security.abode.event_controller.sio"),
         ):
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
         # Verify entry was set up with aggressive preset
         assert mock_entry.state is ConfigEntryState.LOADED
-        assert mock_entry.data[CONF_POLLING_INTERVAL] == aggressive_preset["interval"]
+        assert (
+            mock_entry.data[CONF_POLLING_INTERVAL]
+            == aggressive_preset[CONF_POLLING_INTERVAL]
+        )
 
     async def test_user_switches_between_presets(
         self,
@@ -307,14 +351,16 @@ class TestConfigurationPresets:
                 CONF_USERNAME: "user@example.com",
                 CONF_PASSWORD: "password123",
                 CONF_POLLING: True,
-                CONF_POLLING_INTERVAL: POLLING_PRESETS["balanced"]["interval"],
+                CONF_POLLING_INTERVAL: POLLING_PRESETS["balanced"][
+                    CONF_POLLING_INTERVAL
+                ],
             },
         )
         mock_entry.add_to_hass(hass)
 
         with (
             patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-            patch("abode.event_controller.sio"),
+            patch("custom_components.abode_security.abode.event_controller.sio"),
         ):
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
@@ -324,14 +370,18 @@ class TestConfigurationPresets:
             mock_entry,
             data={
                 **mock_entry.data,
-                CONF_POLLING_INTERVAL: POLLING_PRESETS["conservative"]["interval"],
+                CONF_POLLING_INTERVAL: POLLING_PRESETS["conservative"][
+                    CONF_POLLING_INTERVAL
+                ],
             },
         )
         await hass.async_block_till_done()
 
         # Verify update
         updated_interval = mock_entry.data[CONF_POLLING_INTERVAL]
-        assert updated_interval == POLLING_PRESETS["conservative"]["interval"]
+        assert (
+            updated_interval == POLLING_PRESETS["conservative"][CONF_POLLING_INTERVAL]
+        )
 
 
 class TestErrorRecoveryScenarios:
@@ -346,7 +396,9 @@ class TestErrorRecoveryScenarios:
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
         # Simulate network errors
         for _ in range(10):
@@ -381,12 +433,12 @@ class TestErrorRecoveryScenarios:
         mock_entry.add_to_hass(hass)
 
         with patch(
-            "custom_components.abode_security.Abode",
+            "custom_components.abode_security.abode.client.Client",
             side_effect=Exception("Missing required credentials"),
         ):
             with (
                 patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-                patch("abode.event_controller.sio"),
+                patch("custom_components.abode_security.abode.event_controller.sio"),
             ):
                 await async_setup_component(hass, DOMAIN, {})
 

--- a/tests/test_entity_lifecycle.py
+++ b/tests/test_entity_lifecycle.py
@@ -84,8 +84,8 @@ async def test_alarm_control_panel_error_handling(
 
     await setup_platform(hass, ALARM_DOMAIN)
 
-    # Verify the entity exists
-    state = hass.states.get("alarm_control_panel.abode_alarm")
+    # Mock alarm in conftest has name="Test Alarm", which slugifies to "test_alarm".
+    state = hass.states.get("alarm_control_panel.test_alarm")
     assert state is not None
 
     # Verify error handling didn't prevent entity creation
@@ -110,16 +110,28 @@ async def test_test_mode_switch_polling_disabled_initially(
 async def test_service_handler_factory_error_handling(
     hass: HomeAssistant, mock_abode
 ) -> None:
-    """Test that service handlers created with factory handle errors gracefully."""
+    """Test that service handlers created with factory handle errors gracefully.
+
+    The factory-built handler (services.py:_create_service_handler) catches
+    `AbodeException` specifically — that's the contract callers should rely
+    on. Generic exceptions are left to propagate.
+    """
+    from custom_components.abode_security.abode.exceptions import (
+        Exception as AbodeException,
+    )
     from custom_components.abode_security.const import DOMAIN
     from custom_components.abode_security.services import SERVICE_ACKNOWLEDGE_ALARM
 
-    # Make acknowledge_timeline_event raise an error
-    mock_abode.acknowledge_timeline_event.side_effect = Exception("API Error")
+    # AbodeException unpacks its `error` arg via `super().__init__(*error)`
+    # and exposes `.errcode`/`.message` from `self.args` (exceptions.py:7-18).
+    # Construct it as a (status, message) tuple to match how production raises
+    # it (e.g. exceptions.py:32, 34).
+    mock_abode.acknowledge_timeline_event.side_effect = AbodeException(
+        (500, "API Error")
+    )
 
     await setup_platform(hass, SWITCH_DOMAIN)
 
-    # Call the service (should not raise even though underlying method fails)
     await hass.services.async_call(
         DOMAIN,
         SERVICE_ACKNOWLEDGE_ALARM,

--- a/tests/test_integration_advanced_features.py
+++ b/tests/test_integration_advanced_features.py
@@ -42,14 +42,16 @@ class TestSmartPollingIntegration:
                 "username": "user@email.com",
                 "password": "password",
                 CONF_POLLING: False,
-                CONF_POLLING_INTERVAL: POLLING_PRESETS["balanced"]["interval"],
+                CONF_POLLING_INTERVAL: POLLING_PRESETS["balanced"][
+                    CONF_POLLING_INTERVAL
+                ],
             },
         )
         mock_entry.add_to_hass(hass)
 
         with (
             patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-            patch("abode.event_controller.sio"),
+            patch("custom_components.abode_security.abode.event_controller.sio"),
         ):
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
@@ -67,10 +69,10 @@ class TestSmartPollingIntegration:
 
         # Get the AbodeSystem instance
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
-
-        # Verify smart polling was initialized
+        abode_system: AbodeSystem = entry.runtime_data
+        # Verify smart polling and event filter were initialized
         assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
         # Record an update
         abode_system.smart_polling.record_update(duration=0.5)
@@ -93,7 +95,9 @@ class TestSmartPollingIntegration:
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
         initial_interval = abode_system.smart_polling.get_optimal_interval()
 
@@ -115,7 +119,9 @@ class TestSmartPollingIntegration:
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
         # Record good performance (fast updates, no errors)
         for _ in range(10):
@@ -149,42 +155,54 @@ class TestEventFilteringIntegration:
 
         with (
             patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-            patch("abode.event_controller.sio"),
+            patch("custom_components.abode_security.abode.event_controller.sio"),
         ):
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
         assert mock_entry.state is ConfigEntryState.LOADED
 
-    async def test_event_filter_allows_all_by_default(
+    async def test_event_filter_allows_known_event_types_by_default(
         self,
         hass: HomeAssistant,
         mock_abode,  # noqa: ARG002
     ) -> None:
-        """Test that event filter allows all events by default."""
+        """Test that event filter allows known event types by default.
+
+        With no explicit `CONF_EVENT_FILTER` configured, the filter falls
+        back to the full `EVENT_TYPES` list — every known event passes,
+        unknown ones are filtered out.
+        """
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
-        # With empty filter (default), all events should be allowed
         assert abode_system.event_filter.should_process("device_update")
         assert abode_system.event_filter.should_process("alarm_state_change")
-        assert abode_system.event_filter.should_process("unknown_event")
+        # Unknown event types are filtered out — the "default" is "known types",
+        # not "everything".
+        assert not abode_system.event_filter.should_process("unknown_event")
 
     async def test_event_filter_filters_specified_events(
         self,
         hass: HomeAssistant,
         mock_abode,  # noqa: ARG002
     ) -> None:
-        """Test that event filter filters specified events."""
+        """Test that an explicit filter narrows accepted events."""
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
-        # Configure the filter to only accept specific events
-        abode_system.event_filter.set_filter(["device_update"])
+        # Reach in and narrow the active filter list to a single event type.
+        # EventFilter has no public setter — this matches the production code
+        # path in `__init__` where the config flow passes the list directly.
+        abode_system.event_filter.filter_types = ["device_update"]
 
         assert abode_system.event_filter.should_process("device_update")
         assert not abode_system.event_filter.should_process("alarm_state_change")
@@ -198,17 +216,20 @@ class TestEventFilteringIntegration:
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
-        abode_system.event_filter.set_filter(["device_update"])
+        abode_system.event_filter.filter_types = ["device_update"]
 
         # Process some events
         abode_system.event_filter.should_process("device_update")
         abode_system.event_filter.should_process("alarm_state_change")
 
         stats = abode_system.event_filter.get_stats()
-        assert stats["total_checks"] == 2
-        assert stats["filtered_count"] == 1
+        assert stats["total"] == 2
+        assert stats["filtered"] == 1
+        assert stats["allowed"] == 1
 
 
 class TestBatchOperationsIntegration:
@@ -315,7 +336,7 @@ class TestOptionsFlowIntegration:
 
         with (
             patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-            patch("abode.event_controller.sio"),
+            patch("custom_components.abode_security.abode.event_controller.sio"),
         ):
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
@@ -350,7 +371,7 @@ class TestOptionsFlowIntegration:
 
         with (
             patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-            patch("abode.event_controller.sio"),
+            patch("custom_components.abode_security.abode.event_controller.sio"),
         ):
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
@@ -384,7 +405,7 @@ class TestOptionsFlowIntegration:
 
         with (
             patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-            patch("abode.event_controller.sio"),
+            patch("custom_components.abode_security.abode.event_controller.sio"),
         ):
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
@@ -408,7 +429,7 @@ class TestEndToEndScenarios:
         mock_abode,  # noqa: ARG002
     ) -> None:
         """Test complete setup with all advanced features enabled."""
-        from custom_components.abode_security.const import CONF_USERNAME
+        from homeassistant.const import CONF_USERNAME
 
         mock_entry = MockConfigEntry(
             domain=DOMAIN,
@@ -426,7 +447,7 @@ class TestEndToEndScenarios:
 
         with (
             patch("custom_components.abode_security.PLATFORMS", [ALARM_DOMAIN]),
-            patch("abode.event_controller.sio"),
+            patch("custom_components.abode_security.abode.event_controller.sio"),
         ):
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
@@ -435,7 +456,7 @@ class TestEndToEndScenarios:
 
         # Verify all systems are initialized
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
 
         assert abode_system.smart_polling is not None
         assert abode_system.event_filter is not None
@@ -449,7 +470,9 @@ class TestEndToEndScenarios:
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
         # Simulate a series of updates with increasing errors
         for i in range(20):
@@ -479,11 +502,14 @@ class TestEndToEndScenarios:
         await setup_platform(hass, ALARM_DOMAIN)
 
         entry = hass.config_entries.async_entries(DOMAIN)[0]
-        abode_system: AbodeSystem = hass.data[DOMAIN][entry.entry_id]["system"]
+        abode_system: AbodeSystem = entry.runtime_data
+        assert abode_system.smart_polling is not None
+        assert abode_system.event_filter is not None
 
-        # Set filter to allow only specific events
+        # Narrow the active filter list (see notes above the equivalent
+        # change in test_event_filter_filters_specified_events).
         allowed_events = ["device_update", "alarm_state_change"]
-        abode_system.event_filter.set_filter(allowed_events)
+        abode_system.event_filter.filter_types = allowed_events
 
         # Test filtering
         test_events = [


### PR DESCRIPTION
## Summary

- Removes the `enabled_tests` allowlist + `pytest_collection_modifyitems` skip hook from `tests/conftest.py`. The mechanism was silently skipping 119 tests on `main`, including ~88 pure unit tests that don't need `hass` at all but got swept in transitively via the autouse `auto_enable_custom_integrations` fixture.
- Fixes the latent test debt the silent skip had been hiding: `mock_abode.get_alarm` was `AsyncMock` (production is sync); stale code-shape assertions in `test_async_*.py`; stale `patch("abode.event_controller.sio")` paths; stale `hass.data[DOMAIN][entry.entry_id]["system"]` access (now `entry.runtime_data`); stale `EventFilter` API surface; `automation.json` fixture wrapped in an array.
- Adds `tests/test_conftest_no_allowlist.py` as a regression guard, anchored on specific token shapes (`enabled_tests = {`, `def pytest_collection_modifyitems`, the verbatim skip-reason text) so it can't be defeated by a comment that mentions the historical name.

## Root cause

The autouse fixture `auto_enable_custom_integrations` depended on `enable_custom_integrations`, which depends on `hass` (from `pytest_homeassistant_custom_component`). Pytest resolves fixture dependencies transitively, so every test had `hass` in its `fixturenames` — including pure unit tests. The allowlist filter then skipped any test whose name wasn't in the ~200-entry set, with the misleading reason "Test infrastructure complete but test needs updates - see phase-4-5.md".

## Test plan

- [x] Added regression test (`tests/test_conftest_no_allowlist.py`) — fails on `main`, passes after fix.
- [x] `uv run pytest tests/` — **195 passed / 119 skipped** → **321 passed / 0 silent skips**. The 108 deselected tests are the mock-server `@pytest.mark.integration` suite (correctly gated).
- [x] `./scripts/check.sh` (ruff + ruff format + mypy + pyright + pytest with coverage) — green.
- [x] Verified no test in the suite still carries the historical "Test infrastructure complete..." skip reason.

Fixes #74
