### PR TITLE
chore(deps): bump @rollup/plugin-terser to 1.0.0; drop serialize-javascript override

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "@eslint/js": "^10.0.1",
         "@open-wc/testing": "^4.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/mocha": "^10.0.10",
         "@types/sinon": "^21.0.0",
@@ -924,18 +924,18 @@
       }
     },
     "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "serialize-javascript": "^6.0.1",
+        "serialize-javascript": "^7.0.3",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0||^3.0.0||^4.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,14 +25,11 @@
   "dependencies": {
     "lit": "^3.2.0"
   },
-  "overrides": {
-    "serialize-javascript": "^7.0.5"
-  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@open-wc/testing": "^4.0.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
-    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/mocha": "^10.0.10",
     "@types/sinon": "^21.0.0",


### PR DESCRIPTION
## Summary

Bumps `@rollup/plugin-terser` from `0.4.4` to `1.0.0` and removes the `overrides.serialize-javascript` block that PR #78 added as a temporary workaround.

- `@rollup/plugin-terser@1.0.0` ships with `serialize-javascript ^7.0.3`, so the transitive resolves to `7.0.5` (the same version the override was forcing) directly via the upstream range.
- The `overrides` block is now redundant and removed.
- `npm audit --audit-level=high` reports 0 vulnerabilities.

This is **PR-2** in the planned sequence from `~/.claude/plans/78-and-60-have-partitioned-pebble.md`. Split out of failing Dependabot #86, whose remaining items (TypeScript 6, `@rollup/plugin-typescript` 12, `@rollup/plugin-node-resolve` 16) will land in a follow-up PR-3.

### Notes

- `@rollup/plugin-terser@1.0.0` bumps its node engine requirement from `>=14` to `>=20`. Verified compatible with `frontend/.nvmrc` (`20.19.0`) and all CI workflows.

## Test plan

- [x] `npm --prefix frontend run build` — succeeds (rollup → `www/abode-security-panel.js`)
- [x] `npm --prefix frontend test` — 110/110 tests pass
- [x] `npm --prefix frontend audit --audit-level=high` — 0 vulnerabilities
- [x] `serialize-javascript` resolves to a single entry at `7.0.5`
- [ ] CI green on PR

Closes #80.
