### PR TITLE
ci(deps): ignore PyTurboJPEG 2.x in Dependabot until HA bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,14 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 10
+    ignore:
+      # PyTurboJPEG is not imported by this project; it ships in [dev] only
+      # so HA's camera/stream integrations can load during tests. We pin to
+      # HA's exact version (currently 1.8.3) to avoid dev/prod drift, so
+      # Dependabot must not propose its own bumps to 2.x. Revisit when HA
+      # bumps past 1.x.
+      - dependency-name: "pyturbojpeg"
+        versions: ["2.x"]
     groups:
       dev-deps:
         patterns:


### PR DESCRIPTION
## Summary

Adds a Dependabot `ignore` directive for `pyturbojpeg` 2.x.

PR-5 (#97) deliberately pinned `PyTurboJPEG==1.8.3` to match HA 2026.5's hard pin and avoid dev/prod drift. PyTurboJPEG isn't imported by this project — it ships in `[dev]` only so HA's `camera`/`stream` integrations can load during tests.

Without this directive Dependabot keeps proposing `2.2.0` (most recently in #98). Codifying the "match HA" decision in `dependabot.yml` prevents the same conversation from recurring weekly.

The `versions: ["2.x"]` form blocks 2.x specifically. Future 1.9.x bumps (if HA moves there) are still allowed.

After this merges, close #98; Dependabot will recreate the dev-deps group next Monday with just the safe `mypy 2.0.0 → 2.1.0` bump.

## Test plan

- [x] YAML parses cleanly
- [x] `ignore` directive correctly scoped under the pip ecosystem (sibling to `groups`)
- [x] `dependency-name: "pyturbojpeg"` matches PyPI's canonical name (Dependabot is case-insensitive)
- [x] `versions: ["2.x"]` is the documented Dependabot v2 shorthand for the entire 2.x line
- [ ] CI green on PR
