### PR TITLE
ci: gate 108 integration tests in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,57 @@ jobs:
       - name: Run tests with pytest
         run: uv run pytest tests/ -v --tb=short
 
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and start mock Abode server
+        # The conftest mock_server fixture detects an already-running server
+        # at MOCK_SERVER_URL and skips its own docker-compose call, so we
+        # manage container lifecycle here for clearer failure attribution.
+        run: docker compose up -d --build mock-abode
+
+      - name: Wait for mock server health
+        run: |
+          for i in {1..60}; do
+            if curl -sf http://localhost:8000/health > /dev/null; then
+              echo "Mock server ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Mock server failed to become ready within 60s"
+          docker compose logs mock-abode
+          exit 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run integration tests
+        # Override pyproject's `addopts = "... -m 'not integration'"` explicitly.
+        # Without `-o addopts=...`, this job would rely on pytest's rightmost-`-m`-wins
+        # CLI override semantics — fragile across pytest versions, and silent if it
+        # ever regresses (zero tests would "pass", reintroducing the #77 bug).
+        run: |
+          uv run pytest tests/ \
+            -o addopts="--cov=custom_components/abode_security --cov-report=term-missing" \
+            -m integration -v --tb=short
+
+      - name: Show mock server logs on failure
+        if: failure()
+        run: docker compose logs mock-abode
+
+      - name: Stop mock server
+        if: always()
+        run: docker compose down
+
   frontend-build:
     name: Build Frontend
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Closes #77 by adding an `integration-tests` job to `tests.yaml` that boots the mock Abode server, runs the 108-test `pytest -m integration` suite, and tears down on completion.

Before this, those 108 integration tests across 11 files were silently deselected in CI because `pyproject.toml`'s `[tool.pytest.ini_options].addopts` includes `-m 'not integration'` — correct for local default runs, but the CI job inherited the same filter. Same silent-rot failure mode as #74, one layer up.

### Design decisions

Confirmed with reviewer before coding:

- **Second job in `tests.yaml`** (vs new workflow file) — jobs parallelize within a workflow, conceptually all "tests".
- **Required check** (not advisory) — tests pass today (verified in #76); no reason to expect flake.
- **Explicit container lifecycle in CI** — the conftest `mock_server` fixture detects an already-running server at `MOCK_SERVER_URL` and skips its own `docker-compose` call, so the workflow owns start/stop for clearer failure attribution. Local-dev behavior is unchanged.

### Hermetic invocation

The pytest run uses `-o addopts="--cov=... --cov-report=..."` to explicitly override `pyproject.toml`'s `addopts` (which contains `-m 'not integration'`). Without this, the CI invocation would rely on pytest's "rightmost-`-m`-wins" CLI semantics — fragile across pytest versions, and silent if it ever regresses (zero tests would "pass", reintroducing the #77 bug). The override closes that vector while preserving coverage reporting.

### e2e-tests.yaml

`e2e-tests.yaml` re-enablement is tracked as a separate follow-up in #100 — kept out of this PR to keep the diff focused on the `-m integration` half.

## Test plan

- [x] `uv run pytest tests/ -m integration --collect-only -q` — 108/429 tests collected (321 deselected)
- [x] `uv run pytest tests/ -o addopts="--cov=..." -m integration --collect-only -q` — still 108 collected
- [x] `yaml.safe_load` parses the workflow cleanly
- [ ] First CI run on the PR validates the docker-compose lifecycle + 108-test pass

Closes #77.
