### PR TITLE
feat(security): admin-gate sensitive read-only websocket commands

### DIFF
--- a/custom_components/abode_security/websocket_api.py
+++ b/custom_components/abode_security/websocket_api.py
@@ -68,11 +68,19 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
       trigger which alarms in which modes) also require admin:
       `actions/{list,get}`, `entities/{sensors,alarms}`. Non-admin users
       should not be able to enumerate the alarm wiring even read-only.
-    - Read-only commands that expose only generic metadata are open to
-      any authenticated HA user: `modes/list` (just mode names),
-      `config/get` (currently just `debounce_seconds`). If you add a
-      sensitive field to `ConfigStore`, either gate `config/get` or
-      split the schema — don't quietly widen what non-admins can read.
+    - Read-only commands that expose only non-sensitive metadata are
+      open to any authenticated HA user:
+      - `modes/list` returns `{id, name, icon, action_count, active}`
+        per mode. `active` discloses the current armed state, which
+        HA's standard state APIs already expose for the Abode
+        `alarm_control_panel` entity (resolved dynamically by
+        `find_abode_alarm_panel`), so gating here would be security
+        theater. `action_count` is a count only, not the actions
+        themselves (those go through the gated `actions/*`).
+      - `config/get` (currently just `debounce_seconds`). If you add a
+        sensitive field to `ConfigStore`, either gate `config/get` or
+        split the schema — don't quietly widen what non-admins can
+        read.
 
     If you add a new command, check `@require_admin` matches one of the
     three buckets above. New mutating commands or topology-exposing reads

--- a/custom_components/abode_security/websocket_api.py
+++ b/custom_components/abode_security/websocket_api.py
@@ -58,7 +58,26 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def async_register_websocket_commands(hass: HomeAssistant) -> None:
-    """Register WebSocket commands for Abode Security."""
+    """Register WebSocket commands for Abode Security.
+
+    Admin-gating policy (per #52 audit):
+
+    - All mutating commands require admin: `actions/{create,update,delete,
+      toggle,test}`, `modes/set`, `config/set`.
+    - Read-only commands that expose alarm-system topology (which sensors
+      trigger which alarms in which modes) also require admin:
+      `actions/{list,get}`, `entities/{sensors,alarms}`. Non-admin users
+      should not be able to enumerate the alarm wiring even read-only.
+    - Read-only commands that expose only generic metadata are open to
+      any authenticated HA user: `modes/list` (just mode names),
+      `config/get` (currently just `debounce_seconds`). If you add a
+      sensitive field to `ConfigStore`, either gate `config/get` or
+      split the schema — don't quietly widen what non-admins can read.
+
+    If you add a new command, check `@require_admin` matches one of the
+    three buckets above. New mutating commands or topology-exposing reads
+    MUST add `@require_admin`.
+    """
     # Action CRUD endpoints
     websocket_api.async_register_command(hass, websocket_actions_list)
     websocket_api.async_register_command(hass, websocket_actions_get)
@@ -90,6 +109,7 @@ def _get_action_manager(hass: HomeAssistant) -> ActionManager | None:
         vol.Required("type"): "abode_security/actions/list",
     }
 )
+@require_admin
 @async_response
 async def websocket_actions_list(
     hass: HomeAssistant,
@@ -115,6 +135,7 @@ async def websocket_actions_list(
         vol.Required("action_id"): str,
     }
 )
+@require_admin
 @async_response
 async def websocket_actions_get(
     hass: HomeAssistant,
@@ -452,6 +473,7 @@ async def websocket_modes_list(
         vol.Required("mode_id"): vol.In(VALID_MODES),
     }
 )
+@require_admin
 @async_response
 async def websocket_modes_set(
     hass: HomeAssistant,
@@ -503,6 +525,7 @@ async def websocket_modes_set(
         vol.Required("type"): "abode_security/entities/sensors",
     }
 )
+@require_admin
 @async_response
 async def websocket_entities_sensors(
     hass: HomeAssistant,
@@ -542,6 +565,7 @@ ALARM_TYPES = {
         vol.Required("type"): "abode_security/entities/alarms",
     }
 )
+@require_admin
 @async_response
 async def websocket_entities_alarms(
     hass: HomeAssistant,

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -607,39 +607,71 @@ class TestWebSocketActionsAPI:
 
 
 @pytest.mark.usefixtures("mock_abode", "setup_websocket_api")
-class TestWebSocketActionsAuthorization:
-    """Tests for WebSocket actions API authorization."""
+class TestWebSocketAdminGating:
+    """Verify admin-gating on WebSocket commands matches the policy in
+    websocket_api.py's `async_register_websocket_commands` docstring.
 
-    async def test_ws_actions_list_no_admin_required(
-        self, hass, hass_ws_client
+    Non-admin users (HA "read-only" group) must be rejected with
+    `unauthorized` for:
+      - All mutating commands.
+      - Topology-exposing read-only commands: actions/{list,get},
+        entities/{sensors,alarms}.
+
+    Non-admin users must be allowed for the two non-sensitive read-only
+    commands: modes/list, config/get.
+    """
+
+    @pytest.mark.parametrize(
+        ("command_type", "extra_payload"),
+        [
+            ("abode_security/actions/list", {}),
+            ("abode_security/actions/get", {"action_id": "any"}),
+            ("abode_security/entities/sensors", {}),
+            ("abode_security/entities/alarms", {}),
+            ("abode_security/modes/set", {"mode_id": "home"}),
+        ],
+        ids=[
+            "actions/list",
+            "actions/get",
+            "entities/sensors",
+            "entities/alarms",
+            "modes/set",
+        ],
+    )
+    async def test_admin_gated_commands_reject_non_admin(
+        self,
+        hass,
+        hass_ws_client,
+        hass_read_only_access_token,
+        command_type,
+        extra_payload,
     ) -> None:
-        """Test that list action does not require admin."""
-        # hass_ws_client creates an admin by default, but list should work for non-admin too
-        # For now, just verify it works - we'll add non-admin test when fixture is available
-        client = await hass_ws_client(hass)
-        await client.send_json({"id": 1, "type": "abode_security/actions/list"})
+        """Non-admin users get `unauthorized` from admin-gated commands."""
+        client = await hass_ws_client(hass, hass_read_only_access_token)
+        await client.send_json({"id": 1, "type": command_type, **extra_payload})
         response = await client.receive_json()
+
+        assert not response["success"]
+        assert response["error"]["code"] == "unauthorized"
+
+    async def test_modes_list_allowed_for_non_admin(
+        self, hass, hass_ws_client, hass_read_only_access_token
+    ) -> None:
+        """`modes/list` exposes only mode names; non-admin users may call it."""
+        client = await hass_ws_client(hass, hass_read_only_access_token)
+        await client.send_json({"id": 1, "type": "abode_security/modes/list"})
+        response = await client.receive_json()
+
         assert response["success"]
 
-    async def test_ws_actions_get_no_admin_required(self, hass, hass_ws_client) -> None:
-        """Test that get action does not require admin."""
-        manager = _get_manager(hass)
-        action = await manager.async_create(
-            name="Test",
-            modes=["home"],
-            sensor_entity_ids=["binary_sensor.door"],
-            alarm_entity_ids=["switch.panic_alarm"],
-        )
-
-        client = await hass_ws_client(hass)
-        await client.send_json(
-            {
-                "id": 1,
-                "type": "abode_security/actions/get",
-                "action_id": action.id,
-            }
-        )
+    async def test_config_get_allowed_for_non_admin(
+        self, hass, hass_ws_client, hass_read_only_access_token
+    ) -> None:
+        """`config/get` exposes only non-sensitive settings; non-admin OK."""
+        client = await hass_ws_client(hass, hass_read_only_access_token)
+        await client.send_json({"id": 1, "type": "abode_security/config/get"})
         response = await client.receive_json()
+
         assert response["success"]
 
 

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -624,18 +624,42 @@ class TestWebSocketAdminGating:
     @pytest.mark.parametrize(
         ("command_type", "extra_payload"),
         [
+            # Topology-exposing read-only commands.
             ("abode_security/actions/list", {}),
             ("abode_security/actions/get", {"action_id": "any"}),
             ("abode_security/entities/sensors", {}),
             ("abode_security/entities/alarms", {}),
+            # Mutating commands. Payloads are schema-valid so the request
+            # reaches the @require_admin check rather than failing
+            # earlier in @websocket_command's schema validator.
+            (
+                "abode_security/actions/create",
+                {
+                    "name": "x",
+                    "modes": ["home"],
+                    "sensor_entity_ids": ["binary_sensor.door"],
+                    "alarm_entity_ids": ["switch.panic_alarm"],
+                },
+            ),
+            ("abode_security/actions/update", {"action_id": "any"}),
+            ("abode_security/actions/delete", {"action_id": "any"}),
+            ("abode_security/actions/toggle", {"action_id": "any"}),
+            ("abode_security/actions/test", {"action_id": "any"}),
             ("abode_security/modes/set", {"mode_id": "home"}),
+            ("abode_security/config/set", {}),
         ],
         ids=[
             "actions/list",
             "actions/get",
             "entities/sensors",
             "entities/alarms",
+            "actions/create",
+            "actions/update",
+            "actions/delete",
+            "actions/toggle",
+            "actions/test",
             "modes/set",
+            "config/set",
         ],
     )
     async def test_admin_gated_commands_reject_non_admin(
@@ -657,7 +681,8 @@ class TestWebSocketAdminGating:
     async def test_modes_list_allowed_for_non_admin(
         self, hass, hass_ws_client, hass_read_only_access_token
     ) -> None:
-        """`modes/list` exposes only mode names; non-admin users may call it."""
+        """`modes/list` returns mode metadata and current active state,
+        which HA's state APIs already expose; non-admin users may call it."""
         client = await hass_ws_client(hass, hass_read_only_access_token)
         await client.send_json({"id": 1, "type": "abode_security/modes/list"})
         response = await client.receive_json()


### PR DESCRIPTION
## Summary

Audit-driven lockdown per #52. The 6 read-only WS commands previously had no admin gate, so any authenticated HA user (including read-only "guest" accounts) could enumerate the alarm-system topology and read the action configuration.

### Policy (now documented in `async_register_websocket_commands`)

Three buckets:

- **Mutating — require admin.** `actions/{create,update,delete,toggle,test}`, `modes/set`, `config/set`.
- **Read-only but topology-exposing — require admin.** `actions/{list,get}`, `entities/{sensors,alarms}`. Non-admin users should not be able to enumerate the alarm wiring (which sensors trigger which alarms in which modes) even read-only.
- **Read-only and non-sensitive — open.** `modes/list` (just mode names), `config/get` (currently just `debounce_seconds`).

### Newly admin-gated by this PR

- `actions/list`
- `actions/get`
- `entities/sensors`
- `entities/alarms`

### Bonus finding during audit: `modes/set` was un-gated

`modes/set` is mutating (it changes the alarm's active mode — including disarm), but had no `@require_admin`. #52's body claimed all 7 mutating commands were already gated; the audit caught the discrepancy. Fixed in the same PR. The decorator-ordering pattern matches the existing gated commands.

### Tests

- Replaced the misleading `TestWebSocketActionsAuthorization` class. The old class had 2 tests named `test_ws_actions_*_no_admin_required` that only verified admin success and never actually tested non-admin rejection.
- New `TestWebSocketAdminGating` class:
  - Parametrized `test_admin_gated_commands_reject_non_admin` over the 5 newly-gated commands, asserting `error.code == "unauthorized"` for `hass_read_only_access_token`.
  - Positive tests confirming `modes/list` and `config/get` work for non-admin (defends against future over-gating).
- Net +5 tests (326 vs 321).

## Test plan

- [x] `./scripts/check.sh` — 326 unit tests pass; ruff, mypy, pyright all clean
- [x] Decorator order verified — `@websocket_command → @require_admin → @async_response → async def` matches existing pattern
- [x] Parametrized rejection covers all 5 newly-gated commands
- [x] Positive tests confirm `modes/list` and `config/get` remain accessible to non-admin
- [x] CI green on PR

Closes #52.
