### PR TITLE
fix(socketio): rename dispatch handlers to match protocol verbs

### DIFF
--- a/custom_components/abode_security/abode/socketio.py
+++ b/custom_components/abode_security/abode/socketio.py
@@ -475,11 +475,11 @@ class SocketIO:
         except KeyError:
             log.debug("Ignoring SocketIO message: %s", message)
 
-    async def _on_socketio_connected(self, _data: str = "") -> None:
+    async def _on_socketio_connect(self, _data: str = "") -> None:
         self._socketio_connected = True
         log.debug("SocketIO Connected")
 
-    async def _on_socketio_disconnected(self, _data: str = "") -> None:
+    async def _on_socketio_disconnect(self, _data: str = "") -> None:
         self._socketio_connected = False
         log.debug("SocketIO Disconnected")
         if self._websocket is not None:

--- a/custom_components/abode_security/manifest.json
+++ b/custom_components/abode_security/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["custom_components.abode_security"],
   "requirements": ["platformdirs", "aiohttp"],
   "single_config_entry": true,
-  "version": "1.0.0-dev-20251211-112901",
+  "version": "1.0.0-dev-20260512-180429",
   "minimum_home_assistant_version": "2024.1.0",
   "diagnostics": true
 }

--- a/tests/test_socketio_dispatch.py
+++ b/tests/test_socketio_dispatch.py
@@ -1,0 +1,50 @@
+"""SocketIO inbound packet dispatch.
+
+Regression: after the lomond-removal rewrite, `_on_engineio_message` resolved
+`SocketIO.codes[0]` to `"connect"` and tried `getattr(self, "_on_socketio_connect")`,
+but only `_on_socketio_connected` existed. Every successful namespace join
+triggered an `AttributeError` that killed the receive task and made every HA
+entity go unavailable. These tests feed raw Socket.IO v4 packets directly
+through `_on_websocket_text` so that mismatch surfaces in CI.
+"""
+
+from custom_components.abode_security.abode.socketio import SocketIO
+
+
+class TestInboundPacketDispatch:
+    """Raw Engine.IO/Socket.IO packets must route to existing handlers."""
+
+    async def test_connect_packet_sets_socketio_connected(self):
+        """Packet '40' = EngineIO message (4) + SocketIO connect (0).
+
+        The server sends this on every successful namespace join. If the
+        method/dispatch-table names diverge again, this raises AttributeError
+        and the test fails — mirroring the production crash.
+        """
+        s = SocketIO(url="ws://example/socket.io/")
+
+        await s._on_websocket_text("40")
+
+        assert s._socketio_connected is True
+
+    async def test_disconnect_packet_clears_socketio_connected(self):
+        """Packet '41' = EngineIO message (4) + SocketIO disconnect (1)."""
+        s = SocketIO(url="ws://example/socket.io/")
+        s._socketio_connected = True
+
+        await s._on_websocket_text("41")
+
+        assert s._socketio_connected is False
+
+    async def test_every_socketio_code_has_a_handler(self):
+        """Belt-and-braces: each entry in SocketIO.codes must resolve to a
+        callable on the instance. Catches future drift between the dispatch
+        table and the method names without needing one test per code."""
+        s = SocketIO(url="ws://example/socket.io/")
+
+        for name in SocketIO.codes:
+            handler = getattr(s, f"_on_socketio_{name}", None)
+            assert callable(handler), (
+                f"SocketIO.codes has '{name}' but no _on_socketio_{name} method; "
+                "the message dispatcher will AttributeError on this packet."
+            )


### PR DESCRIPTION
## Summary

- Production hotfix: inbound SocketIO `connect`/`disconnect` packets killed the receive task with `AttributeError: 'SocketIO' object has no attribute '_on_socketio_connect'`, making every HA entity go unavailable on every install of the last release.
- Root cause: `SocketIO.codes` maps codes to verbs (`connect`, `disconnect`, `event`, `error`) and the dispatcher does `getattr(self, f"_on_socketio_{name}")`, but the post-lomond rewrite (`7d7c2a31fb40`) left two handler methods at their past-tense names (`_on_socketio_connected`/`_on_socketio_disconnected`). The crash was deterministic on the first inbound message after a successful namespace join.
- Fix: rename the two methods to match the protocol verbs. The internal state flag `self._socketio_connected` is unchanged (it names a state, not a packet). External listeners subscribe to `"connected"`/`"disconnected"` events that are fired from the **websocket-transport** handlers, not these SocketIO-protocol handlers, so no callback subscriptions break.

## Why diagnostics showed what they did

- `connection_status: disconnected`, all entities `unavailable` — the receive task died with the unhandled `AttributeError`; no reconnect happens because the task is dead, not in the backoff path.
- `consecutive_connect_failures: 0` — the failure counter only increments inside `_run`'s retry loop after `_step` returns. An uncaught exception bypasses it.
- `last_packet_age_seconds: 310` (frozen ~5 min) — the timestamp froze when the task died.
- "Restart Home Assistant to finish setup" — `async_unload_entry` awaits the already-failed task, which re-raises the `AttributeError`, so unload fails and HA forces a full restart on every reload. Fixed automatically by the same change.

## Tests

New `tests/test_socketio_dispatch.py`:

1. `test_connect_packet_sets_socketio_connected` — feeds raw `40` packet through `_on_websocket_text`, asserts the flag flips to `True`. Reproduces the production `AttributeError` exactly on the pre-fix tree.
2. `test_disconnect_packet_clears_socketio_connected` — same for the `41` packet.
3. `test_every_socketio_code_has_a_handler` — drift-guard: iterates `SocketIO.codes` and asserts every key resolves to a callable method. Catches future re-introductions of this exact bug without needing one test per code.

All 374 unit tests pass; `./scripts/check.sh` (ruff + mypy + pyright + pytest) clean.

## Test plan

- [x] Failing regression tests added first; confirmed they reproduce the `AttributeError` on `main`.
- [x] Rename applied; regression tests pass.
- [x] `./scripts/check.sh` — clean (374 passed).
- [ ] Reviewer to confirm no callback path references the old method names.
- [ ] After merge: deploy `custom_components/abode_security` to the prod HA host per `DEPLOY.local.md`; download fresh diagnostics; expect `connection_status: connected`, ticking `last_packet_age_seconds`, all entities back to real states, and the "restart Home Assistant" notice cleared.

## Follow-ups (intentionally out of scope here)

- Count "task died with unhandled exception" toward `consecutive_connect_failures` so future regressions of this shape surface in diagnostics rather than masquerading as a clean disconnect.
- Add an end-to-end test for the `_on_socketio_error` runtime contract (the introspection test only covers its name).
