### PR TITLE
fix(modes): live-reactive active mode + cancel mid-arming

### DIFF
--- a/custom_components/abode_security/websocket_api.py
+++ b/custom_components/abode_security/websocket_api.py
@@ -622,7 +622,18 @@ async def websocket_modes_list(
             }
         )
 
-    connection.send_result(msg["id"], {"modes": modes})
+    # Surface the panel entity_id so the frontend can derive the active
+    # mode from `hass.states[panel].state` at render time instead of the
+    # cached `active` flag (#124). The cached flag is read once at fetch
+    # time; SocketIO-driven panel transitions during the 30–60s entry/exit
+    # delay arrive later and never propagate to the snapshot.
+    connection.send_result(
+        msg["id"],
+        {
+            "modes": modes,
+            "panel_entity_id": panel_state.entity_id if panel_state else None,
+        },
+    )
 
 
 @websocket_command(

--- a/frontend/src/__tests__/modes-tab.test.ts
+++ b/frontend/src/__tests__/modes-tab.test.ts
@@ -371,43 +371,38 @@ describe('ModesTab', () => {
       expect(el.shadowRoot?.querySelector('abode-modal')).to.equal(null);
     });
 
-    it('keeps the mode grid visible during the post-switch refresh (no loading flash)', async () => {
-      // The post-switch refresh must not flip _loading=true — that would
-      // replace the grid (and the "Switching…" pending label on the target
-      // card) with "Loading modes...". Achieved by passing `silent: true`
-      // to _loadData.
-      let modesListCalls = 0;
-      let resolveRefresh!: (v: { modes: ReturnType<typeof createMockModes> }) => void;
-      const refreshPromise = new Promise<{ modes: ReturnType<typeof createMockModes> }>(
-        (resolve) => {
-          resolveRefresh = resolve;
-        },
-      );
-
+    it('shows "Switching…" on the target card while live state has not caught up (#124)', async () => {
+      // After the WS `modes/set` returns, the alarm_control_panel state in
+      // hass.states still reflects the OLD mode until the Abode SocketIO
+      // event lands (which lags through the 30–60s entry/exit countdown).
+      // The target card must display a pending indicator until live state
+      // catches up so the arming is visible and the rest of the grid is
+      // usable for cancel.
       const hass = createMockHass({
         callWS: ((params: { type: string }) => {
           if (params.type === 'abode_security/modes/set') {
             return Promise.resolve({ success: true });
           }
           if (params.type === 'abode_security/modes/list') {
-            modesListCalls += 1;
-            // First call: initial connectedCallback load. Resolve immediately.
-            // Second call: post-switch refresh — keep pending so we can
-            // observe the mid-refresh DOM state.
-            if (modesListCalls === 1) {
-              return Promise.resolve({ modes: createMockModes() });
-            }
-            return refreshPromise;
+            return Promise.resolve({
+              modes: createMockModes(),
+              panel_entity_id: 'alarm_control_panel.abode_alarm',
+            });
           }
           if (params.type === 'abode_security/actions/list') {
             return Promise.resolve({ actions: [] });
           }
           return Promise.resolve({ success: true });
         }) as HomeAssistant['callWS'],
+        states: {
+          'alarm_control_panel.abode_alarm': {
+            entity_id: 'alarm_control_panel.abode_alarm',
+            state: 'disarmed',
+          },
+        },
       });
 
       const el = await fixture<ModesTab>(html` <abode-modes-tab .hass=${hass}></abode-modes-tab> `);
-      // Wait for initial load to settle.
       await aTimeout(0);
       await elementUpdated(el);
 
@@ -421,77 +416,14 @@ describe('ModesTab', () => {
         el.shadowRoot?.querySelectorAll('button[slot="footer"]') ?? [],
       ).find((b) => b.classList.contains('primary')) as HTMLButtonElement;
       confirmBtn.click();
-      // setMode resolves → _loadData fires (suspended on refreshPromise).
-      // Yield enough microtasks for the chain to suspend on the controlled
-      // promise.
       await aTimeout(0);
       await elementUpdated(el);
 
-      // Mid-refresh assertions: grid is still rendered and the "Loading
-      // modes..." spinner is NOT shown.
+      // Live state is still `disarmed` (Abode SocketIO event hasn't landed).
+      // The Away card must show the pending label.
       const cards = el.shadowRoot?.querySelectorAll('.mode-card');
-      expect(cards?.length, 'mode grid must stay visible').to.be.greaterThan(0);
-      expect(el.shadowRoot?.textContent ?? '').to.not.include('Loading modes...');
-      // The target card still shows the pending label.
       const awayCardMid = Array.from(cards ?? []).find((c) => c.textContent?.includes('Away'));
       expect(awayCardMid?.textContent).to.include('Switching');
-
-      // Resolve so the test runner exits cleanly.
-      resolveRefresh({ modes: createMockModes() });
-      await refreshPromise;
-      await aTimeout(0);
-    });
-
-    it('routes a post-switch _loadData failure to the banner, not the full-page error', async () => {
-      // setMode succeeds, but the immediate refresh fails. The previous
-      // implementation let _loadData write to `_error`, which would render
-      // a full-page error that wipes the just-confirmed switch.
-      let setSucceeded = false;
-      const hass = createMockHass({
-        callWS: ((params: { type: string }) => {
-          if (params.type === 'abode_security/modes/set') {
-            setSucceeded = true;
-            return Promise.resolve({ success: true });
-          }
-          if (params.type === 'abode_security/modes/list' && setSucceeded) {
-            return Promise.reject(new Error('refresh blip'));
-          }
-          if (params.type === 'abode_security/modes/list') {
-            return Promise.resolve({ modes: createMockModes() });
-          }
-          if (params.type === 'abode_security/actions/list') {
-            return Promise.resolve({ actions: [] });
-          }
-          return Promise.resolve({ success: true });
-        }) as HomeAssistant['callWS'],
-      });
-
-      const el = await fixture<ModesTab>(html` <abode-modes-tab .hass=${hass}></abode-modes-tab> `);
-      // @ts-expect-error - accessing private property for testing
-      el._modes = createMockModes();
-      // @ts-expect-error - accessing private property for testing
-      el._loading = false;
-      await elementUpdated(el);
-
-      const awayCard = Array.from(el.shadowRoot?.querySelectorAll('.mode-card') ?? []).find(
-        (card) => card.textContent?.includes('Away'),
-      ) as HTMLElement;
-      (awayCard.querySelector('.switch-button') as HTMLButtonElement).click();
-      await elementUpdated(el);
-      const confirmBtn = Array.from(
-        el.shadowRoot?.querySelectorAll('button[slot="footer"]') ?? [],
-      ).find((b) => b.classList.contains('primary')) as HTMLButtonElement;
-      confirmBtn.click();
-      await aTimeout(0);
-      await elementUpdated(el);
-
-      // Banner present, full-page error absent, mode grid still rendered.
-      const banner = el.shadowRoot?.querySelector('.operation-error');
-      expect(banner, 'refresh failure must surface as banner').to.exist;
-      expect(banner?.textContent).to.include('refresh failed');
-      const fullPageError = el.shadowRoot?.querySelector('.error');
-      expect(fullPageError, 'full-page error must NOT be rendered').to.equal(null);
-      expect(el.shadowRoot?.querySelectorAll('.mode-card')?.length).to.be.greaterThan(0);
     });
 
     it('shows an error banner when setMode rejects', async () => {
@@ -535,6 +467,286 @@ describe('ModesTab', () => {
       // backend internals out of the UI (mirrors actions-tab convention).
       expect(banner?.textContent).to.include('Failed to change mode');
       expect(banner?.getAttribute('role')).to.equal('alert');
+    });
+  });
+
+  describe('live panel state reactivity (#124)', () => {
+    // Background: pre-#124, `mode.active` came from the snapshot returned at
+    // `modes/list` fetch time. The Abode SocketIO update that follows an
+    // arm/disarm (which can lag 30–60s through the entry/exit countdown)
+    // never propagated to the snapshot, so the grid showed the stale mode
+    // and Standby had no Switch button (preventing cancel of an in-progress
+    // arming). The fix: derive `active` from `hass.states[panel].state` at
+    // render time.
+
+    function makeHass(panelState: string, callWS?: HomeAssistant['callWS']): HomeAssistant {
+      return createMockHass({
+        callWS:
+          callWS ??
+          (((params: { type: string }) => {
+            if (params.type === 'abode_security/modes/set') {
+              return Promise.resolve({ success: true });
+            }
+            if (params.type === 'abode_security/modes/list') {
+              // Return a stale `active` flag — the live derivation must
+              // ignore it in favor of hass.states.
+              const stale = createMockModes(); // home=active by default
+              return Promise.resolve({
+                modes: stale,
+                panel_entity_id: 'alarm_control_panel.abode_alarm',
+              });
+            }
+            if (params.type === 'abode_security/actions/list') {
+              return Promise.resolve({ actions: [] });
+            }
+            return Promise.resolve({ success: true });
+          }) as HomeAssistant['callWS']),
+        states: {
+          'alarm_control_panel.abode_alarm': {
+            entity_id: 'alarm_control_panel.abode_alarm',
+            state: panelState,
+          },
+        },
+      });
+    }
+
+    it('derives active card from hass.states, not the cached snapshot', async () => {
+      // Snapshot says home active; live state says armed_away. Away must
+      // be the active card.
+      const hass = makeHass('armed_away');
+      const el = await fixture<ModesTab>(html` <abode-modes-tab .hass=${hass}></abode-modes-tab> `);
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      const activeCard = el.shadowRoot?.querySelector('.mode-card.active');
+      expect(activeCard, 'one card must be active').to.exist;
+      expect(activeCard?.textContent).to.include('Away');
+      expect(activeCard?.textContent).to.not.include('Home');
+    });
+
+    it('updates the active card when hass.states changes (live reactivity)', async () => {
+      const hass = makeHass('disarmed');
+      const el = await fixture<ModesTab>(html` <abode-modes-tab .hass=${hass}></abode-modes-tab> `);
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      // Initially: standby is the live active mode.
+      let activeCard = el.shadowRoot?.querySelector('.mode-card.active');
+      expect(activeCard?.textContent).to.include('Standby');
+
+      // HA reassigns `hass` on every state change. Simulate the SocketIO
+      // event that flips the panel to armed_away.
+      el.hass = {
+        ...hass,
+        states: {
+          'alarm_control_panel.abode_alarm': {
+            entity_id: 'alarm_control_panel.abode_alarm',
+            state: 'armed_away',
+          },
+        },
+      };
+      await elementUpdated(el);
+
+      activeCard = el.shadowRoot?.querySelector('.mode-card.active');
+      expect(activeCard?.textContent).to.include('Away');
+    });
+
+    it('Standby card stays clickable while arming is pending (cancel)', async () => {
+      // While the system is mid-arming Away (target=away, live=disarmed),
+      // the Standby card must still expose a Switch button so the user can
+      // cancel by switching back to standby.
+      const hass = makeHass('disarmed');
+      const el = await fixture<ModesTab>(html` <abode-modes-tab .hass=${hass}></abode-modes-tab> `);
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      // Initiate switch to Away.
+      const awayCard = Array.from(el.shadowRoot?.querySelectorAll('.mode-card') ?? []).find((c) =>
+        c.textContent?.includes('Away'),
+      ) as HTMLElement;
+      (awayCard.querySelector('.switch-button') as HTMLButtonElement).click();
+      await elementUpdated(el);
+      const confirmBtn = Array.from(
+        el.shadowRoot?.querySelectorAll('button[slot="footer"]') ?? [],
+      ).find((b) => b.classList.contains('primary')) as HTMLButtonElement;
+      confirmBtn.click();
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      // Live state is still disarmed → standby is "active". But because a
+      // switch is pending, standby must still show a Switch button (cancel
+      // affordance), not the "Current mode" label.
+      const standbyCard = Array.from(el.shadowRoot?.querySelectorAll('.mode-card') ?? []).find(
+        (c) => c.textContent?.includes('Standby'),
+      ) as HTMLElement;
+      const standbyBtn = standbyCard.querySelector('.switch-button') as HTMLButtonElement;
+      expect(standbyBtn, 'standby must expose Switch button during pending arming').to.exist;
+      expect(standbyBtn.disabled, 'standby cancel button must be clickable').to.equal(false);
+    });
+
+    it('clears pending state when hass.states reaches the target mode', async () => {
+      // After live state catches up, the "Switching…" indicator goes away
+      // and the target card becomes the live-active "Current mode" card.
+      const hass = makeHass('disarmed');
+      const el = await fixture<ModesTab>(html` <abode-modes-tab .hass=${hass}></abode-modes-tab> `);
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      // Switch to Away.
+      const awayCard = Array.from(el.shadowRoot?.querySelectorAll('.mode-card') ?? []).find((c) =>
+        c.textContent?.includes('Away'),
+      ) as HTMLElement;
+      (awayCard.querySelector('.switch-button') as HTMLButtonElement).click();
+      await elementUpdated(el);
+      (
+        Array.from(el.shadowRoot?.querySelectorAll('button[slot="footer"]') ?? []).find((b) =>
+          b.classList.contains('primary'),
+        ) as HTMLButtonElement
+      ).click();
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      // SocketIO catches up.
+      el.hass = {
+        ...hass,
+        states: {
+          'alarm_control_panel.abode_alarm': {
+            entity_id: 'alarm_control_panel.abode_alarm',
+            state: 'armed_away',
+          },
+        },
+      };
+      await elementUpdated(el);
+
+      // Pending cleared → Away is now the "Current mode" card.
+      const updatedAwayCard = Array.from(el.shadowRoot?.querySelectorAll('.mode-card') ?? []).find(
+        (c) => c.textContent?.includes('Away'),
+      );
+      expect(updatedAwayCard?.textContent).to.not.include('Switching');
+      expect(updatedAwayCard?.textContent).to.include('Current mode');
+    });
+
+    it('does not clear pending or surface an error when a superseded switch rejects', async () => {
+      // Race scenario: live=armed_home. User clicks Switch to Away (setMode
+      // hangs), then clicks Switch to Standby to redirect before the first
+      // call completes. _targetMode is now 'standby' (live=armed_home, so
+      // the pending indicator sticks). If the original Away setMode then
+      // rejects, its catch block must not clobber the standby pending
+      // indicator or surface a misleading error for the stale request.
+      let rejectAway!: (e: Error) => void;
+      const awayPromise = new Promise<void>((_resolve, reject) => {
+        rejectAway = reject;
+      });
+      let awaySent = false;
+
+      const hass = createMockHass({
+        callWS: ((params: { type: string; mode_id?: string }) => {
+          if (params.type === 'abode_security/modes/set' && params.mode_id === 'away') {
+            awaySent = true;
+            return awayPromise;
+          }
+          if (params.type === 'abode_security/modes/set' && params.mode_id === 'standby') {
+            return Promise.resolve({ success: true });
+          }
+          if (params.type === 'abode_security/modes/list') {
+            return Promise.resolve({
+              modes: createMockModes(),
+              panel_entity_id: 'alarm_control_panel.abode_alarm',
+            });
+          }
+          if (params.type === 'abode_security/actions/list') {
+            return Promise.resolve({ actions: [] });
+          }
+          return Promise.resolve({ success: true });
+        }) as HomeAssistant['callWS'],
+        states: {
+          'alarm_control_panel.abode_alarm': {
+            entity_id: 'alarm_control_panel.abode_alarm',
+            state: 'armed_home',
+          },
+        },
+      });
+
+      const el = await fixture<ModesTab>(html` <abode-modes-tab .hass=${hass}></abode-modes-tab> `);
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      // First switch: Away. setMode hangs on awayPromise.
+      const awayCard = Array.from(el.shadowRoot?.querySelectorAll('.mode-card') ?? []).find((c) =>
+        c.textContent?.includes('Away'),
+      ) as HTMLElement;
+      (awayCard.querySelector('.switch-button') as HTMLButtonElement).click();
+      await elementUpdated(el);
+      (
+        Array.from(el.shadowRoot?.querySelectorAll('button[slot="footer"]') ?? []).find((b) =>
+          b.classList.contains('primary'),
+        ) as HTMLButtonElement
+      ).click();
+      await aTimeout(0);
+      await elementUpdated(el);
+      expect(awaySent, 'first setMode(away) must be in-flight').to.equal(true);
+
+      // Second switch: Standby. This overwrites _targetMode = 'standby'.
+      const standbyCard = Array.from(el.shadowRoot?.querySelectorAll('.mode-card') ?? []).find(
+        (c) => c.textContent?.includes('Standby'),
+      ) as HTMLElement;
+      (standbyCard.querySelector('.switch-button') as HTMLButtonElement).click();
+      await elementUpdated(el);
+      (
+        Array.from(el.shadowRoot?.querySelectorAll('button[slot="footer"]') ?? []).find((b) =>
+          b.classList.contains('primary'),
+        ) as HTMLButtonElement
+      ).click();
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      // Standby setMode resolved. Live state is still armed_home, so
+      // _targetMode = 'standby' stays as the visible pending indicator.
+      const standbyCardMid = Array.from(el.shadowRoot?.querySelectorAll('.mode-card') ?? []).find(
+        (c) => c.textContent?.includes('Standby'),
+      );
+      expect(standbyCardMid?.textContent).to.include('Switching');
+
+      // Now reject the stale Away request.
+      rejectAway(new Error('away setMode failed'));
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      // Standby pending must still be visible — the stale-rejection guard
+      // kept _targetMode and skipped the error banner.
+      const standbyCardAfter = Array.from(el.shadowRoot?.querySelectorAll('.mode-card') ?? []).find(
+        (c) => c.textContent?.includes('Standby'),
+      );
+      expect(
+        standbyCardAfter?.textContent,
+        'standby pending must survive the stale rejection',
+      ).to.include('Switching');
+      const banner = el.shadowRoot?.querySelector('.operation-error');
+      expect(banner, 'stale rejection must not show an error banner').to.equal(null);
+    });
+
+    it('falls back to the cached active flag when panel_entity_id is null', async () => {
+      // Accounts without an Abode alarm device — backend returns
+      // panel_entity_id=null. We still render the snapshot's `active` flag
+      // so the rest of the panel works (matches pre-#124 behavior).
+      const hass = createMockHass({
+        callWS: ((params: { type: string }) => {
+          if (params.type === 'abode_security/modes/list') {
+            const modes = createMockModes(); // home is active in fixture
+            return Promise.resolve({ modes, panel_entity_id: null });
+          }
+          if (params.type === 'abode_security/actions/list') {
+            return Promise.resolve({ actions: [] });
+          }
+          return Promise.resolve({ success: true });
+        }) as HomeAssistant['callWS'],
+      });
+      const el = await fixture<ModesTab>(html` <abode-modes-tab .hass=${hass}></abode-modes-tab> `);
+      await aTimeout(0);
+      await elementUpdated(el);
+
+      const activeCard = el.shadowRoot?.querySelector('.mode-card.active');
+      expect(activeCard?.textContent).to.include('Home');
     });
   });
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -23,13 +23,24 @@ export async function fetchActions(hass: HomeAssistant): Promise<AbodeAction[]> 
 }
 
 /**
- * Fetch all modes with their action counts.
+ * Fetch all modes with their action counts, plus the alarm panel entity_id
+ * the frontend should watch for live state reactivity (#124).
+ *
+ * `panel_entity_id` is null when no abode alarm_control_panel is registered
+ * (e.g. accounts without an alarm device). It is also optional in the type
+ * so older backends (and test fixtures) that omit the field round-trip
+ * cleanly — consumers must fall back to the cached `active` flag in that
+ * case.
  */
-export async function fetchModes(hass: HomeAssistant): Promise<AbodeMode[]> {
-  const response = await hass.callWS<{ modes: AbodeMode[] }>({
+export interface ModesListResponse {
+  modes: AbodeMode[];
+  panel_entity_id?: string | null;
+}
+
+export async function fetchModes(hass: HomeAssistant): Promise<ModesListResponse> {
+  return hass.callWS<ModesListResponse>({
     type: 'abode_security/modes/list',
   });
-  return response.modes;
 }
 
 /**

--- a/frontend/src/modes-tab.ts
+++ b/frontend/src/modes-tab.ts
@@ -1,8 +1,24 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import type { PropertyValues } from 'lit';
 import type { HomeAssistant, AbodeMode, AbodeAction, Mode } from './types';
 import { fetchModes, fetchActions, setMode } from './api';
 import './abode-modal';
+
+// Mirrors backend STATE_TO_MODE (websocket_api.py). Replicated here so the
+// frontend can derive the active mode from `hass.states[panel].state` at
+// render time and stay live-reactive — the cached snapshot lags 30–60s
+// behind the SocketIO update through the entry/exit countdown (#124).
+const STATE_TO_MODE: Record<string, Mode> = {
+  disarmed: 'standby',
+  armed_home: 'home',
+  armed_away: 'away',
+};
+
+// Safety bound on the pending indicator. The Abode panel's exit delay is
+// typically 30–60s; this covers the worst case plus headroom. Without it, a
+// stuck SocketIO subscription would freeze the "Switching…" UI indefinitely.
+const PENDING_TIMEOUT_MS = 90_000;
 
 /**
  * Modes tab — displays the three Abode arming modes (standby/home/away)
@@ -20,15 +36,23 @@ export class ModesTab extends LitElement {
   @state() private _actions: AbodeAction[] = [];
   @state() private _loading = true;
   @state() private _error: string | null = null;
+  // Entity to watch for live alarm state (#124). Null when no panel is
+  // registered — UI falls back to the cached `active` flag on each mode.
+  @state() private _panelEntityId: string | null = null;
 
-  // Mode-switching state (#1):
-  // - _confirmMode holds the target mode while the confirm dialog is open.
-  // - _settingModeId is set during the in-flight WS call so the UI can show
-  //   a busy state and prevent re-entry.
+  // Mode-switching state:
+  // - _confirmMode holds the target mode while the confirm dialog is open (#1).
+  // - _targetMode (#124) is the mode the user just confirmed switching to.
+  //   It persists past the WS round-trip until `hass.states[panel].state`
+  //   reaches the corresponding alarm_control_panel state, so the
+  //   "Switching…" indicator stays visible through the Abode entry/exit
+  //   countdown. Cleared in willUpdate when live state matches, on error,
+  //   or via PENDING_TIMEOUT_MS as a safety net.
   // - _setError surfaces a failed switch as a dismissible banner.
   @state() private _confirmMode: AbodeMode | null = null;
-  @state() private _settingModeId: Mode | null = null;
+  @state() private _targetMode: Mode | null = null;
   @state() private _setError: string | null = null;
+  private _pendingTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Aborted on disconnect so a late-resolving fetch can't write state to a
   // detached element (panel tab switches destroy the inactive tab — closes #29).
@@ -278,32 +302,82 @@ export class ModesTab extends LitElement {
   disconnectedCallback() {
     this._abort?.abort();
     this._abort = null;
+    this._clearPendingTimer();
     super.disconnectedCallback();
   }
 
-  private async _loadData(options: { silent?: boolean } = {}) {
+  private async _loadData() {
     this._abort?.abort();
     const controller = new AbortController();
     this._abort = controller;
     const { signal } = controller;
 
-    // `silent` keeps `_loading` untouched so an in-place refresh doesn't
-    // flash the full-page "Loading modes..." spinner over the visible grid.
-    // The initial connectedCallback load is loud (default); post-switch
-    // refresh is silent.
-    if (!options.silent) this._loading = true;
+    this._loading = true;
     this._error = null;
 
     try {
-      const [modes, actions] = await Promise.all([fetchModes(this.hass), fetchActions(this.hass)]);
+      const [modesResponse, actions] = await Promise.all([
+        fetchModes(this.hass),
+        fetchActions(this.hass),
+      ]);
       if (signal.aborted) return;
-      this._modes = modes;
+      this._modes = modesResponse.modes;
+      // `?? null` normalizes older backends (and test fixtures) that omit
+      // the field, keeping the field's declared type accurate at runtime.
+      this._panelEntityId = modesResponse.panel_entity_id ?? null;
       this._actions = actions;
     } catch (err) {
       if (signal.aborted) return;
       this._error = err instanceof Error ? err.message : 'Failed to load data';
     } finally {
-      if (!signal.aborted && !options.silent) this._loading = false;
+      if (!signal.aborted) this._loading = false;
+    }
+  }
+
+  /**
+   * Live-derived active mode from `hass.states[panel].state` (#124). Returns
+   * null when the panel entity is unknown (older backend, no alarm device)
+   * or in an intermediate state (e.g. `arming`, `pending`, `triggered`) the
+   * mode mapping doesn't cover. Callers fall back to the cached `mode.active`
+   * flag in that case.
+   */
+  private _liveActiveMode(): Mode | null {
+    if (!this._panelEntityId) return null;
+    const state = this.hass.states?.[this._panelEntityId]?.state;
+    if (!state) return null;
+    return STATE_TO_MODE[state] ?? null;
+  }
+
+  private _activeMode(): Mode | null {
+    const live = this._liveActiveMode();
+    if (live !== null) return live;
+    // Fallback: no live source (panel_entity_id null or unknown state) →
+    // use the cached snapshot's `active` flag.
+    return this._modes.find((m) => m.active)?.id ?? null;
+  }
+
+  private _clearPendingTimer() {
+    if (this._pendingTimer !== null) {
+      clearTimeout(this._pendingTimer);
+      this._pendingTimer = null;
+    }
+  }
+
+  /** Drop the "Switching…" pending state. Called from the success path
+   * (live state caught up), the error path, and the safety-timeout path. */
+  private _resetPending() {
+    this._targetMode = null;
+    this._clearPendingTimer();
+  }
+
+  willUpdate(_changed: PropertyValues) {
+    // Drop the pending indicator once live state catches up. This is the
+    // success path through the Abode entry/exit countdown — the SocketIO
+    // event arrives, `hass` is reassigned by HA, willUpdate fires, and we
+    // clear `_targetMode` so the target card flips from "Switching…" to
+    // "Current mode".
+    if (this._targetMode !== null && this._liveActiveMode() === this._targetMode) {
+      this._resetPending();
     }
   }
 
@@ -329,9 +403,15 @@ export class ModesTab extends LitElement {
   }
 
   private _requestSwitch(mode: AbodeMode) {
-    // No-op for already-active mode (the UI suppresses the button anyway,
-    // this is a defense-in-depth check in case a programmatic caller fires).
-    if (mode.active || this._settingModeId !== null) return;
+    // No-op when this mode is already the live-active one (the UI
+    // suppresses the button anyway; this is defense-in-depth for
+    // programmatic callers).
+    //
+    // Note: we deliberately do NOT block on `_targetMode !== null` here.
+    // Allowing a second confirm during a pending switch is what makes
+    // "switch to standby = cancel arming" reachable when the first switch
+    // is still mid-flight or live state lags (#124).
+    if (this._activeMode() === mode.id && this._targetMode === null) return;
     // Clear any stale error from a prior failed attempt — opening a fresh
     // confirm dialog implies the user has acknowledged the previous one.
     this._setError = null;
@@ -342,33 +422,38 @@ export class ModesTab extends LitElement {
     if (!this._confirmMode) return;
     const target = this._confirmMode;
     this._confirmMode = null;
-    this._settingModeId = target.id;
+    this._targetMode = target.id;
     this._setError = null;
+    // Safety net: clear the pending indicator if live state never catches
+    // up (lost SocketIO subscription, network blip). Without this the
+    // target card would say "Switching…" forever.
+    this._clearPendingTimer();
+    this._pendingTimer = setTimeout(() => {
+      this._pendingTimer = null;
+      this._targetMode = null;
+    }, PENDING_TIMEOUT_MS);
     try {
       await setMode(this.hass, target.id);
     } catch (err) {
       // Match actions-tab convention: log the raw exception for diagnostics,
       // surface a fixed user-facing label so backend internals don't leak.
       console.error('Failed to set mode:', err);
-      this._setError = 'Failed to change mode';
-      this._settingModeId = null;
+      // Stale-rejection guard: a second _confirmSwitch (e.g. the user
+      // clicking Standby to cancel arming) can run while this one is still
+      // awaiting setMode. If our request was superseded, _targetMode now
+      // points at the newer target — don't clear it or show an error for
+      // this stale attempt.
+      if (this._targetMode === target.id) {
+        this._setError = 'Failed to change mode';
+        this._resetPending();
+      }
       return;
     }
-    // Switch succeeded — refresh so the active flag flips. Pass
-    // `silent: true` so the grid stays visible (with its "Switching…"
-    // pending label on the targeted card) instead of flashing
-    // "Loading modes..." over the full tab during the refresh.
-    //
-    // _loadData catches its own exception and writes to `this._error`,
-    // which would trigger the full-page error branch in render() and wipe
-    // the successful-switch UX. Detect that case and re-route the message
-    // through the dismissible banner instead.
-    await this._loadData({ silent: true });
-    if (this._error) {
-      this._setError = `Mode changed; refresh failed: ${this._error}`;
-      this._error = null;
-    }
-    this._settingModeId = null;
+    // Switch succeeded. Don't reload modes — the active flag is derived
+    // live from `hass.states[panel].state` (#124), and the SocketIO update
+    // that flips that state will re-render us via the @property hass
+    // reassignment HA performs on every state change. `_targetMode` keeps
+    // the "Switching…" indicator visible until then.
   }
 
   render() {
@@ -429,11 +514,17 @@ export class ModesTab extends LitElement {
 
   private _renderModeCard(mode: AbodeMode) {
     const actionsForMode = this._getActionsForMode(mode.id);
-    const isPending = this._settingModeId === mode.id;
-    const anySwitchPending = this._settingModeId !== null;
+    const activeMode = this._activeMode();
+    const isActive = activeMode === mode.id;
+    const isTarget = this._targetMode === mode.id;
+    // While a switch is pending, the target card shows "Switching…" and
+    // every other card (including the live-active one) shows a Switch
+    // button. That's what makes Standby clickable mid-arming so the user
+    // can cancel (#124).
+    const showCurrent = isActive && this._targetMode === null;
 
     return html`
-      <div class="mode-card ${mode.active ? 'active' : ''}">
+      <div class="mode-card ${isActive ? 'active' : ''}">
         <div class="mode-header">
           <div class="mode-icon">
             <ha-icon icon=${mode.icon}></ha-icon>
@@ -442,7 +533,7 @@ export class ModesTab extends LitElement {
             <h3>${mode.name}</h3>
             <div class="badges">
               ${this._renderActionCountBadge(mode)}
-              ${mode.active ? html`<span class="badge active">Active</span>` : ''}
+              ${isActive ? html`<span class="badge active">Active</span>` : ''}
             </div>
           </div>
         </div>
@@ -462,16 +553,16 @@ export class ModesTab extends LitElement {
               </ul>
             `
           : html`<div class="empty-actions">No actions configured</div>`}
-        ${mode.active
+        ${showCurrent
           ? html`<div class="current-mode-label">Current mode</div>`
           : html`
               <button
                 class="switch-button"
-                ?disabled=${anySwitchPending}
+                ?disabled=${isTarget}
                 aria-label=${`Switch to ${mode.name} mode`}
                 @click=${() => this._requestSwitch(mode)}
               >
-                ${isPending ? 'Switching…' : `Switch to ${mode.name}`}
+                ${isTarget ? `Switching to ${mode.name}…` : `Switch to ${mode.name}`}
               </button>
             `}
       </div>

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -901,6 +901,44 @@ class TestWebSocketModesAPI:
             assert "icon" in mode
             assert mode["icon"].startswith("mdi:")
 
+    async def test_ws_modes_list_includes_panel_entity_id(
+        self, hass, hass_ws_client
+    ) -> None:
+        """Response includes `panel_entity_id` so the frontend can watch
+        `hass.states[panel].state` for live reactivity (#124).
+
+        Without this, the Modes tab reads the active mode from a stale
+        snapshot returned at `modes/list` time and never reflects the
+        SocketIO-driven state updates that follow an arm/disarm.
+        """
+        hass.states.async_set("alarm_control_panel.abode_alarm", "disarmed")
+
+        client = await hass_ws_client(hass)
+        await client.send_json({"id": 1, "type": "abode_security/modes/list"})
+        response = await client.receive_json()
+
+        assert response["success"]
+        assert (
+            response["result"]["panel_entity_id"] == "alarm_control_panel.abode_alarm"
+        )
+
+    async def test_ws_modes_list_panel_entity_id_none_when_no_panel(
+        self, hass, hass_ws_client
+    ) -> None:
+        """`panel_entity_id` is None when no abode alarm panel is registered.
+
+        The frontend treats None as "no live source" and falls back to the
+        cached `active` flag, so the regression mode (pre-#124) still works
+        for accounts without an alarm device.
+        """
+        # No alarm_control_panel state set — find_abode_alarm_panel returns None.
+        client = await hass_ws_client(hass)
+        await client.send_json({"id": 1, "type": "abode_security/modes/list"})
+        response = await client.receive_json()
+
+        assert response["success"]
+        assert response["result"]["panel_entity_id"] is None
+
     # --- Set mode (#1) ---
 
     async def test_ws_modes_set_home(self, hass, hass_ws_client) -> None:


### PR DESCRIPTION
## Summary

- Modes tab now derives the active card from `hass.states[panel].state` at render time, so the SocketIO update that follows an arm/disarm is reflected live instead of requiring a manual refresh.
- A `_targetMode` flag keeps a "Switching to X…" indicator visible from confirm-click through the 30–60s Abode entry/exit countdown until live state catches up (or 90s safety timeout, or error).
- Non-target cards stay clickable while a switch is pending, so Standby becomes the cancel-arming affordance.

## Root cause

`modes/list` returns a snapshot of `mode.active` taken at fetch time. After a user-initiated arm, the alarm_control_panel state in `hass.states` only updates when Abode's SocketIO event fires — which lags through the entry/exit countdown. The Modes tab never reactively re-read `hass.states` for the active mode, so the grid showed the stale mode and Standby lacked a Switch button (preventing cancel). Backend `modes/list` now also returns `panel_entity_id`; frontend uses it to read live state.

## Test plan

- [x] Added backend tests for `panel_entity_id` (present and `None` fallback).
- [x] Added frontend tests for live derivation, cross-`hass`-reassignment reactivity, Standby-cancel affordance during pending arm, pending-clear on catch-up, and the `panel_entity_id == null` fallback.
- [x] Updated/removed obsolete tests that exercised the deleted post-switch silent reload.
- [x] Full quality gates pass: ruff, format, mypy, pyright, pytest (488), eslint, prettier, tsc, web-test-runner (173).

Fixes #124
