### PR TITLE
fix(scheduled-arming): disarm never fires due to derive_state boundary

### DIFF
--- a/custom_components/abode_security/scheduling/manager.py
+++ b/custom_components/abode_security/scheduling/manager.py
@@ -237,9 +237,21 @@ class ScheduleManager:
             last_error=pair.last_error,
         )
         self._validate(updated)
+        # A pending one-shot disarm timer (created on-demand by a successful arm)
+        # is NOT re-registered by _register_pair_timers, so the blanket
+        # _unregister_timers below would silently drop it.  Editing the name or
+        # toggling `enabled` while the panel is armed would then leave the panel
+        # armed with no auto-disarm.  Detect a pending disarm and re-establish it
+        # after the update: recompute from the updated pair so a changed
+        # disarm_time reschedules correctly, while a name-only edit is a no-op.
+        had_pending_disarm = (pair_id, "disarm") in self._pending_handles
         self._unregister_timers(pair_id)
         await self._store.async_update(updated)
         self._register_pair_timers(pair_id)
+        # Disabling the pair (or clearing the arm anchor) leaves it disarm-less;
+        # async_disarm no-ops on a disabled pair, so don't re-arm a timer there.
+        if had_pending_disarm and updated.enabled and updated.last_armed_at is not None:
+            self._schedule_disarm(updated)
         return updated
 
     async def async_delete(self, pair_id: str) -> bool:
@@ -536,6 +548,13 @@ class ScheduleManager:
             # Pair was armed and never disarmed — determine action.
             ed = expected_disarm_at(pair, last_armed_at=pair.last_armed_at, tz=tz)
 
+            # Intentional asymmetry with derive_state: reconcile uses a strict
+            # `now >= ed` with NO grace, while derive_state allows
+            # DISARM_WINDOW_GRACE for an on-time timer that fires a hair late.
+            # On startup there is no in-flight timer to be late, and we must be
+            # conservative — a genuinely missed window (HA was down) must be
+            # marked disarmed WITHOUT auto-disarming the panel hours later. Do
+            # NOT add the grace here to "match" derive_state.
             if now >= ed:
                 pair.last_disarmed_at = now
                 pair.last_skip_reason = SkipReason.RECONCILE_WINDOW_ELAPSED

--- a/custom_components/abode_security/scheduling/state_machine.py
+++ b/custom_components/abode_security/scheduling/state_machine.py
@@ -12,6 +12,16 @@ from enum import Enum, auto
 
 from .models import ScheduledPair
 
+# Grace tolerance applied to the "window elapsed" check.  The one-shot disarm
+# timer (async_call_later) fires at-or-slightly-after expected_disarm_at, so the
+# utcnow() read inside async_disarm is always a hair past the boundary.  Without
+# this grace, a strict `now > expected_disarm` would treat an on-time disarm as
+# a missed window and silently skip it.  Kept small: it must exceed worst-case
+# event-loop latency between the timer firing and the utcnow() read (sub-second
+# to seconds) while staying far below a genuinely-missed window (e.g. HA down for
+# hours), which is left to the conservative startup-reconcile path.
+DISARM_WINDOW_GRACE = timedelta(minutes=5)
+
 
 class PairState(Enum):
     """Derived run-state for a single schedule pair."""
@@ -36,8 +46,8 @@ def derive_state(pair: ScheduledPair, *, now: datetime, tz: tzinfo) -> PairState
     ):
         return PairState.IDLE
     expected_disarm = expected_disarm_at(pair, last_armed_at=pair.last_armed_at, tz=tz)
-    if now > expected_disarm:
-        return PairState.IDLE  # window has elapsed
+    if now > expected_disarm + DISARM_WINDOW_GRACE:
+        return PairState.IDLE  # window has elapsed (past the grace tolerance)
     return PairState.ARMED
 
 

--- a/tests/test_schedule_runtime.py
+++ b/tests/test_schedule_runtime.py
@@ -10,13 +10,14 @@ mock Abode server.  Time control relies on:
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.abode_security.const import (
@@ -31,6 +32,7 @@ from custom_components.abode_security.scheduling.manager import ScheduleManager
 from custom_components.abode_security.scheduling.mode_changer import ModeChangeFailed
 from custom_components.abode_security.scheduling.models import ChangeSource, SkipReason
 from custom_components.abode_security.scheduling.scheduler import CancelHandle
+from custom_components.abode_security.scheduling.state_machine import expected_disarm_at
 from custom_components.abode_security.scheduling.store import SchedulesStore
 
 # ---------------------------------------------------------------------------
@@ -52,6 +54,20 @@ def _capture_events(hass: HomeAssistant, event_name: str) -> list[dict[str, Any]
 
     hass.bus.async_listen(event_name, _listener)
     return events
+
+
+async def _expected_disarm(manager: ScheduleManager, pair_id: str) -> datetime:
+    """Compute a pair's expected disarm instant using the live HA timezone.
+
+    The runtime hass fixture sets a non-UTC timezone, so tests must derive the
+    disarm boundary the same way the manager does rather than hardcoding a UTC
+    wall-clock time.
+    """
+    pair = await manager.async_get(pair_id)
+    assert pair is not None and pair.last_armed_at is not None
+    return expected_disarm_at(
+        pair, last_armed_at=pair.last_armed_at, tz=dt_util.DEFAULT_TIME_ZONE
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -222,8 +238,12 @@ class TestArmFlow:
 
         fired = _capture_events(hass, EVENT_SCHEDULE_FIRED)
 
-        # Advance clock and fire time-based callbacks for disarm.
-        disarm_dt = datetime(2030, 1, 8, 6, 0, 0, tzinfo=UTC)
+        # Advance clock and fire time-based callbacks for disarm.  Fire a couple
+        # of seconds PAST the exact boundary: async_call_later fires at-or-after
+        # the scheduled instant, so the real utcnow() read inside async_disarm is
+        # always a hair late.  Pinning the clock to the exact microsecond would
+        # mask the boundary bug (see test_disarm_fires_when_slightly_past_boundary).
+        disarm_dt = await _expected_disarm(manager, pair.id) + timedelta(seconds=2)
         fake_clock.set(disarm_dt)
         async_fire_time_changed(hass, disarm_dt, fire_all=True)
         await hass.async_block_till_done(wait_background_tasks=True)
@@ -235,6 +255,74 @@ class TestArmFlow:
 
         await hass.async_block_till_done()
         assert any(e["action"] == "disarm" for e in fired)
+
+    @pytest.mark.parametrize(
+        "late_delta",
+        [
+            timedelta(microseconds=1),  # event-loop jitter
+            timedelta(seconds=2),  # task-scheduling latency
+            timedelta(minutes=1),  # event-loop backlog, still within grace
+        ],
+    )
+    async def test_disarm_fires_when_slightly_past_boundary(
+        self,
+        hass: HomeAssistant,
+        manager: ScheduleManager,
+        fake_clock: FakeClock,
+        fake_mode_changer: FakeModeChanger,
+        late_delta: timedelta,
+    ) -> None:
+        """Regression: disarm still fires when utcnow() is just past expected_disarm.
+
+        The one-shot disarm timer fires at-or-after expected_disarm_at, so the
+        clock is always slightly late by the time async_disarm re-checks the
+        derived state.  Before the DISARM_WINDOW_GRACE fix, the strict
+        ``now > expected_disarm`` check treated the pair as IDLE and silently
+        skipped the disarm (panel stayed armed).
+        """
+        _set_panel(hass, "disarmed")
+        pair = await manager.async_create(
+            weekdays=["mon"], arm_time="22:00", disarm_time="06:00"
+        )
+        await manager.async_arm(pair.id)
+        _set_panel(hass, "armed_home")
+
+        fire_at = await _expected_disarm(manager, pair.id) + late_delta
+        fake_clock.set(fire_at)
+        async_fire_time_changed(hass, fire_at, fire_all=True)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        disarm_calls = [c for c in fake_mode_changer.calls if c["target"] == "standby"]
+        assert len(disarm_calls) == 1, f"disarm skipped for late_delta={late_delta}"
+        assert disarm_calls[0]["source"] == ChangeSource.SCHEDULE_DISARM
+
+    async def test_disarm_skipped_when_window_missed_beyond_grace(
+        self,
+        hass: HomeAssistant,
+        manager: ScheduleManager,
+        fake_clock: FakeClock,
+        fake_mode_changer: FakeModeChanger,
+    ) -> None:
+        """A window missed by more than the grace is treated as IDLE — no disarm.
+
+        Protects the safety net: if the timer somehow fires hours late (e.g. the
+        event loop was wedged), we must NOT auto-disarm long after the intended
+        window.  The conservative startup-reconcile path handles genuine misses.
+        """
+        _set_panel(hass, "disarmed")
+        pair = await manager.async_create(
+            weekdays=["mon"], arm_time="22:00", disarm_time="06:00"
+        )
+        await manager.async_arm(pair.id)
+        _set_panel(hass, "armed_home")
+
+        fire_at = await _expected_disarm(manager, pair.id) + timedelta(hours=2)
+        fake_clock.set(fire_at)
+        async_fire_time_changed(hass, fire_at, fire_all=True)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        disarm_calls = [c for c in fake_mode_changer.calls if c["target"] == "standby"]
+        assert len(disarm_calls) == 0
 
     async def test_skip_away_active(
         self,
@@ -410,6 +498,113 @@ class TestArmFlow:
         await manager.async_update(pair.id, arm_time="21:00")
         assert len(cancelled) == 1
         assert (pair.id, "arm") in manager._pending_handles
+
+    async def test_update_while_armed_preserves_disarm(
+        self,
+        hass: HomeAssistant,
+        manager: ScheduleManager,
+        fake_clock: FakeClock,
+        fake_mode_changer: FakeModeChanger,
+    ) -> None:
+        """Editing a pair while armed must NOT drop the pending disarm timer.
+
+        Regression: async_update cancels all handles then re-registers only the
+        arm timer.  Without preserving the on-demand disarm handle, a name edit
+        or `enabled` toggle while the panel is armed would leave it armed with no
+        auto-disarm.
+        """
+        _set_panel(hass, "disarmed")
+        pair = await manager.async_create(
+            weekdays=["mon"], arm_time="22:00", disarm_time="06:00"
+        )
+        await manager.async_arm(pair.id)
+        _set_panel(hass, "armed_home")
+        assert (pair.id, "disarm") in manager._pending_handles
+
+        # Edit an arm-unrelated field while armed.
+        await manager.async_update(pair.id, name="Weeknights")
+        assert (pair.id, "disarm") in manager._pending_handles, (
+            "pending disarm was dropped by async_update"
+        )
+
+        # Disarm must still fire at the (unchanged) expected time.
+        fire_at = await _expected_disarm(manager, pair.id) + timedelta(seconds=2)
+        fake_clock.set(fire_at)
+        async_fire_time_changed(hass, fire_at, fire_all=True)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        disarm_calls = [c for c in fake_mode_changer.calls if c["target"] == "standby"]
+        assert len(disarm_calls) == 1
+
+    async def test_update_disarm_time_while_armed_reschedules(
+        self,
+        hass: HomeAssistant,
+        manager: ScheduleManager,
+        fake_clock: FakeClock,
+        fake_mode_changer: FakeModeChanger,
+    ) -> None:
+        """Editing disarm_time while armed recomputes the disarm boundary.
+
+        The pending disarm is rebuilt from the updated pair (the comment in
+        async_update promises a changed disarm_time reschedules correctly), so
+        the guard now accepts the NEW expected_disarm_at.  A clock value between
+        the old and new boundary — which the original 06:00 window would have
+        treated as elapsed (past grace) and skipped — must still disarm.
+        """
+        _set_panel(hass, "disarmed")
+        pair = await manager.async_create(
+            weekdays=["mon"], arm_time="22:00", disarm_time="06:00"
+        )
+        await manager.async_arm(pair.id)
+        _set_panel(hass, "armed_home")
+        old_disarm = await _expected_disarm(manager, pair.id)
+
+        # Move disarm later (07:00); the timer must follow.
+        await manager.async_update(pair.id, disarm_time="07:00")
+        assert (pair.id, "disarm") in manager._pending_handles
+        new_disarm = await _expected_disarm(manager, pair.id)
+        # New boundary is an hour later than the old one.
+        assert new_disarm == old_disarm + timedelta(hours=1)
+
+        # Fire at a clock between old (06:00) and new (07:00) boundary, well past
+        # the old window's grace.  Under the new disarm_time this is still within
+        # the window → ARMED → disarms.  Had the edit not been applied to the
+        # derived window, this would be treated as elapsed and skipped.
+        fire_at = old_disarm + timedelta(minutes=30)
+        assert fire_at > old_disarm + timedelta(minutes=5)  # past old grace
+        assert fire_at < new_disarm
+        fake_clock.set(fire_at)
+        async_fire_time_changed(hass, fire_at, fire_all=True)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        disarm_calls = [c for c in fake_mode_changer.calls if c["target"] == "standby"]
+        assert len(disarm_calls) == 1
+
+    async def test_update_disabling_while_armed_cancels_disarm(
+        self,
+        hass: HomeAssistant,
+        manager: ScheduleManager,
+        fake_clock: FakeClock,
+        fake_mode_changer: FakeModeChanger,
+    ) -> None:
+        """Disabling a pair while armed cancels the pending disarm (no auto-disarm)."""
+        _set_panel(hass, "disarmed")
+        pair = await manager.async_create(
+            weekdays=["mon"], arm_time="22:00", disarm_time="06:00"
+        )
+        await manager.async_arm(pair.id)
+        _set_panel(hass, "armed_home")
+        assert (pair.id, "disarm") in manager._pending_handles
+
+        fire_at = await _expected_disarm(manager, pair.id) + timedelta(seconds=2)
+        await manager.async_update(pair.id, enabled=False)
+        assert (pair.id, "disarm") not in manager._pending_handles
+
+        fake_clock.set(fire_at)
+        async_fire_time_changed(hass, fire_at, fire_all=True)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        disarm_calls = [c for c in fake_mode_changer.calls if c["target"] == "standby"]
+        assert len(disarm_calls) == 0
 
     async def test_delete_cancels_timers(
         self,

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from custom_components.abode_security.scheduling.models import ScheduledPair
 from custom_components.abode_security.scheduling.state_machine import (
+    DISARM_WINDOW_GRACE,
     PairState,
     derive_state,
     expected_disarm_at,
@@ -57,7 +58,7 @@ class TestDerivState:
     def test_past_expected_disarm_is_idle(self) -> None:
         armed = datetime(2024, 6, 1, 22, 0, tzinfo=_UTC)
         pair = _pair(last_armed_at=armed)
-        now = datetime(2024, 6, 2, 7, 0, tzinfo=_UTC)  # strictly past 06:00
+        now = datetime(2024, 6, 2, 7, 0, tzinfo=_UTC)  # well past 06:00 + grace
         assert derive_state(pair, now=now, tz=_UTC) == PairState.IDLE
 
     def test_at_expected_disarm_time_is_armed(self) -> None:
@@ -67,6 +68,32 @@ class TestDerivState:
         now = datetime(2024, 6, 2, 6, 0, tzinfo=_UTC)  # exactly 06:00
         assert derive_state(pair, now=now, tz=_UTC) == PairState.ARMED
 
+    def test_slightly_past_disarm_within_grace_is_armed(self) -> None:
+        # The one-shot disarm timer fires at-or-after 06:00, so derive_state is
+        # always re-checked a hair late.  Within DISARM_WINDOW_GRACE it must stay
+        # ARMED, otherwise the on-time disarm is silently skipped.
+        armed = datetime(2024, 6, 1, 22, 0, tzinfo=_UTC)
+        pair = _pair(last_armed_at=armed)
+        expected = datetime(2024, 6, 2, 6, 0, tzinfo=_UTC)
+        now = expected + DISARM_WINDOW_GRACE - timedelta(seconds=1)
+        assert derive_state(pair, now=now, tz=_UTC) == PairState.ARMED
+
+    def test_at_grace_boundary_is_armed(self) -> None:
+        # The elapsed check is strict (`now > expected + grace`), so exactly at
+        # the boundary the pair is still ARMED.
+        armed = datetime(2024, 6, 1, 22, 0, tzinfo=_UTC)
+        pair = _pair(last_armed_at=armed)
+        expected = datetime(2024, 6, 2, 6, 0, tzinfo=_UTC)
+        now = expected + DISARM_WINDOW_GRACE
+        assert derive_state(pair, now=now, tz=_UTC) == PairState.ARMED
+
+    def test_just_past_grace_is_idle(self) -> None:
+        armed = datetime(2024, 6, 1, 22, 0, tzinfo=_UTC)
+        pair = _pair(last_armed_at=armed)
+        expected = datetime(2024, 6, 2, 6, 0, tzinfo=_UTC)
+        now = expected + DISARM_WINDOW_GRACE + timedelta(seconds=1)
+        assert derive_state(pair, now=now, tz=_UTC) == PairState.IDLE
+
     def test_overnight_within_window(self) -> None:
         # arm Sat 22:00 UTC, disarm 06:00 next day; now = Sat 23:30 UTC
         armed = datetime(2024, 6, 1, 22, 0, tzinfo=_UTC)  # Saturday
@@ -75,10 +102,10 @@ class TestDerivState:
         assert derive_state(pair, now=now, tz=_UTC) == PairState.ARMED
 
     def test_overnight_past_disarm_is_idle(self) -> None:
-        # arm Sat 22:00 UTC, disarm 06:00 next day; now = Sun 06:01 UTC (strictly past)
+        # arm Sat 22:00 UTC, disarm 06:00 next day; now = Sun 06:10 UTC (past grace)
         armed = datetime(2024, 6, 1, 22, 0, tzinfo=_UTC)
         pair = _pair(arm_time="22:00", disarm_time="06:00", last_armed_at=armed)
-        now = datetime(2024, 6, 2, 6, 1, tzinfo=_UTC)
+        now = datetime(2024, 6, 2, 6, 10, tzinfo=_UTC)
         assert derive_state(pair, now=now, tz=_UTC) == PairState.IDLE
 
     def test_same_day_within_window(self) -> None:
@@ -91,7 +118,7 @@ class TestDerivState:
     def test_same_day_past_disarm_is_idle(self) -> None:
         armed = datetime(2024, 6, 1, 13, 0, tzinfo=_UTC)
         pair = _pair(arm_time="13:00", disarm_time="17:00", last_armed_at=armed)
-        now = datetime(2024, 6, 1, 17, 1, tzinfo=_UTC)  # strictly past 17:00
+        now = datetime(2024, 6, 1, 17, 10, tzinfo=_UTC)  # past 17:00 + grace
         assert derive_state(pair, now=now, tz=_UTC) == PairState.IDLE
 
     def test_dst_forward_unaffected(self) -> None:


### PR DESCRIPTION
## Problem

A scheduled-arming pair (arm 23:00, disarm 06:00) **armed on time but never auto-disarmed** in production. Recorder history for `alarm_control_panel.abode_alarm` (HA tz `America/Los_Angeles`):

| UTC | Local | State |
|---|---|---|
| 2026-05-29 06:00:12 | May 28 23:00 | `armed_home` — scheduled arm fired ✓ |
| (continuous, no `unavailable`) | — | stayed armed; **no HA restart** |
| 2026-05-29 14:07:34 | May 29 07:07 | `disarmed` — **manual** |

The 06:00 scheduled disarm never fired, and the integration was not reloaded in between.

## Root cause

`derive_state` (`scheduling/state_machine.py`) treated the window as elapsed with a strict `if now > expected_disarm`. The one-shot disarm timer (`async_call_later`) fires **at-or-just-after** `expected_disarm`, so when `async_disarm`'s guard re-checked `derive_state`, `now` was a few ms past the boundary → `IDLE` → it **returned early and silently skipped the disarm**. This broke essentially every scheduled disarm.

The original unit test masked the bug by pinning the fake clock to the exact boundary microsecond, where `>` is false.

## Fixes

1. **`state_machine.py`** — add `DISARM_WINDOW_GRACE = timedelta(minutes=5)`; the elapsed check is now `now > expected_disarm + DISARM_WINDOW_GRACE`. On-time/slightly-late disarms fire; a window missed by hours still collapses to `IDLE`. The startup-reconcile path keeps its strict, no-grace `now >= ed` check (documented intentional asymmetry — it must not auto-disarm long after a genuine miss).
2. **`manager.async_update`** — preserve/recompute the on-demand one-shot disarm timer across edits. Previously, editing or toggling a schedule while armed cancelled the pending disarm (it is not re-registered by `_register_pair_timers`), leaving the panel armed with no auto-disarm. Disabling correctly cancels it; changing `disarm_time` reschedules to the new boundary.

## Tests

- Disarm fires when `utcnow()` is `expected + {1µs, 2s, 1min}` (within grace); does **not** fire at `+2h` (beyond grace — safety net preserved).
- `derive_state` grace-boundary unit cases (within grace = ARMED, at boundary = ARMED, just past = IDLE).
- Update-while-armed: name-edit preserves disarm, `disarm_time` edit reschedules, disable cancels.
- New tests compute the boundary via `expected_disarm_at(..., tz=dt_util.DEFAULT_TIME_ZONE)` instead of hardcoding UTC (the runtime test harness runs under US/Pacific).

`./scripts/check.sh` → ruff, mypy, pyright (0 errors), **637 passed**.
