### PR TITLE
ci(deps): use PEP 440 specifier for pip ignore condition

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,14 @@ updates:
       # PyTurboJPEG is not imported by this project; it ships in [dev] only
       # so HA's camera/stream integrations can load during tests. We pin to
       # HA's exact version (currently 1.8.3) to avoid dev/prod drift, so
-      # Dependabot must not propose its own bumps to 2.x. Revisit when HA
+      # Dependabot must not propose its own bumps past 1.x. Revisit when HA
       # bumps past 1.x.
+      #
+      # pip ignore conditions take PEP 440 specifiers, not the `2.x` wildcard
+      # form npm/bundler accept — Dependabot rejects the whole config file if
+      # you use the wildcard here.
       - dependency-name: "pyturbojpeg"
-        versions: ["2.x"]
+        versions: [">=2.0"]
     groups:
       dev-deps:
         patterns:


### PR DESCRIPTION
Dependabot has been rejecting `.github/dependabot.yml` since `a17c7a22`:

```
The property '#/updates/0/ignore/0/versions' includes invalid version
requirements for a pip ignore condition
```

The `pyturbojpeg` ignore entry used `versions: ["2.x"]`. The `x` wildcard is an
npm/bundler form — pip ignore conditions take PEP 440 specifiers. The `prettier`
entry under the npm ecosystem legitimately uses `3.9.x` and is untouched, which
is why only `#/updates/0` was flagged.

## Change

- `versions: ["2.x"]` → `versions: [">=2.0"]`
- Added an inline comment recording the pip-vs-npm syntax difference so it
  doesn't regress.

`>=2.0` is also a slightly better fit for the stated intent than the original:
`2.x` would have left a hypothetical 3.0 eligible for a PR, while `>=2.0` covers
everything past 1.x. The adjacent comment was reworded from "bumps to 2.x" to
"bumps past 1.x" to match.

## Impact

A rejected config pauses **all** Dependabot updates for the repo, not just pip —
so nothing has been proposed since that commit landed. This unblocks the pip,
npm, and github-actions ecosystems together.

## Verification

- YAML parses; `version: 2` and all four update blocks intact.
- `pyproject.toml` pins `PyTurboJPEG==1.8.3` and `uv.lock` resolves 1.8.3, so
  the comment's "currently 1.8.3" is still accurate.
- GitHub re-validates the config once this is on the default branch; the
  `.github/dependabot.yml` check should go green there.
