### PR TITLE
fix(actions): move the alarm timeline lookup off the trigger path

### DIFF
--- a/custom_components/abode_security/abode/devices/alarm.py
+++ b/custom_components/abode_security/abode/devices/alarm.py
@@ -99,7 +99,17 @@ class Alarm(Switch):
         return await self.set_mode('standby')
 
     async def trigger_manual_alarm(self, alarm_type):
-        """Trigger a manual alarm and fetch the corresponding timeline event ID."""
+        """Trigger a manual alarm.
+
+        Returns as soon as the POST is confirmed — the alarm is raised and the
+        monitoring service notified at that point. The timeline event ID needed
+        for a later dismissal is *not* resolved here: that lookup polls for up
+        to ~67s (`timeline_event_retry_delays`), and every caller downstream —
+        the manual alarm switch, the actions executor, the
+        `action_triggered` event that drives the user's notification — used to
+        wait it out. Callers that need the ID run `find_alarm_event_id()`
+        themselves, off the critical path. See issue #194.
+        """
         if not alarm_type:
             raise Exception(ERROR.MISSING_ALARM_TYPE)
 
@@ -129,30 +139,45 @@ class Alarm(Switch):
 
         log.info('Triggered manual alarm %s of type: %s', self.id, alarm_type)
 
-        # The alarm is raised and the monitoring service has been notified.
-        # Everything below is best-effort metadata for later dismissal, and
-        # must never be able to turn a raised alarm into a reported failure:
-        # callers (the actions executor) treat an exception from this method
-        # as "no alarm was raised" and escalate accordingly. The lookup polls
-        # for up to ~67s, so a transient network error inside it is entirely
-        # plausible. Note the module-level `from ..exceptions import Exception`
-        # shadows the builtin, so the guard inside _find_timeline_alarm_event
-        # does NOT catch TimeoutError/aiohttp errors — hence builtins here.
+        return response_object
+
+    async def find_alarm_event_id(self):
+        """Best-effort lookup of the timeline event ID for a raised alarm.
+
+        Only useful for a later dismissal, and never raises apart from
+        CancelledError, which must keep propagating — callers run this detached
+        from the trigger path and cancel it on teardown. By then the alarm is
+        already raised and the monitoring service already notified, so nothing
+        here may turn a raised alarm into a reported failure, and an escaping
+        exception would surface as nothing more than an unretrieved task
+        traceback. The lookup polls for up to ~67s, so a transient network error
+        inside it is entirely plausible. Note the module-level `from ..exceptions
+        import Exception` shadows the builtin, so the guard inside
+        _find_timeline_alarm_event does NOT catch TimeoutError/aiohttp errors —
+        hence builtins here.
+
+        Returns:
+            Event ID if found, None otherwise.
+        """
         try:
             event_id = await self._find_timeline_alarm_event()
+        except asyncio.CancelledError:
+            # Redundant on any Python this runs on — CancelledError has been a
+            # BaseException since 3.8 — but stated rather than inferred. The
+            # abandoned-dismissal report in switch.py hangs off cancellation
+            # reaching the caller, and this module shadows the builtin
+            # `Exception`, so the guard below is already doing something subtle.
+            raise
         except builtins.Exception as exc:
-            log.warning(
-                'Alarm %s was raised, but the timeline lookup failed: %s', alarm_type, exc
-            )
-            event_id = None
+            log.warning('Timeline lookup for alarm %s failed: %s', self.id, exc)
+            return None
 
         if event_id:
-            response_object['event_id'] = event_id
             log.info('Found alarm event ID: %s', event_id)
         else:
             log.warning('Could not find timeline event for triggered alarm')
 
-        return response_object
+        return event_id
 
     async def _find_timeline_alarm_event(self, timeout_seconds=90):
         """Find the most recent alarm event within the timeout window.

--- a/custom_components/abode_security/action_trigger.py
+++ b/custom_components/abode_security/action_trigger.py
@@ -480,15 +480,15 @@ class ActionTriggerCoordinator:
         #  - Re-reading availability looks race-free but isn't: a successful
         #    `async_turn_on` ends in `async_write_ha_state()`, and HA's
         #    `_stringify_state` stamps `unavailable` if availability flipped at
-        #    any point during the call. That call blocks for the inline
-        #    timeline lookup — `timeline_event_retry_delays` sums to 67s — so
-        #    any SocketIO drop in a ~70s window would report a successfully
-        #    dispatched alarm as failed.
+        #    any point during the call. That window used to be ~70s wide (the
+        #    inline timeline lookup); #194 moved that lookup off this path, so
+        #    it is now roughly one round-trip — but a SocketIO drop inside it
+        #    would still report a successfully dispatched alarm as failed.
         #
         # The pre-call checks above carry nearly all the value at none of that
         # cost. What remains is a sub-millisecond window between the pre-check
         # and HA's own `entity_candidates` filter; erring toward "armed" there
-        # is the right trade against a 70-second false-failure window.
+        # is the right trade against reporting a raised alarm as failed.
         return None
 
     async def _capture_and_fire(

--- a/custom_components/abode_security/switch.py
+++ b/custom_components/abode_security/switch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
@@ -52,6 +54,39 @@ ALARM_TYPE_EVENT_CODES = {
     "SMOKE": ["1111"],  # Smoke Detected
     "BURGLAR": ["1133"],  # Burglar Alarm Triggered
 }
+
+
+# How long entity removal waits for a cancelled event-ID lookup to unwind. The
+# lookup only ever awaits network I/O and `asyncio.sleep`, so this is a backstop
+# against blocking teardown, not an expected duration.
+EVENT_ID_TASK_TEARDOWN_SECONDS = 5.0
+
+
+@dataclass
+class _EventIdLookup:
+    """One run of the background timeline event-ID lookup.
+
+    Handed to the task that performs it, so everything about that run is reached
+    through a reference the task holds rather than through entity state a later
+    alarm cycle can overwrite. That is what makes the abandoned-dismissal report
+    exactly-once: one lookup per task, one `finally` per task, and the report
+    reads the object it was given. No identity checks, no verdict that has to
+    survive an await.
+
+    `dismissal_requested` is set by `async_turn_off` when it finds no event ID to
+    dismiss with; `dismissal_settled` when the dismissal was sent, or made moot by
+    the alarm ending; `superseded` when another `TimelineGroups.ALARM` event
+    arrived after the dismissal was asked for, which disqualifies `_timeline_id`
+    as a fallback target; `withheld_target` is that disqualified ID, recorded
+    where the decision is made so the warning can name it without re-reading
+    entity state that may since have moved on.
+    """
+
+    task: asyncio.Task[None] | None = None
+    dismissal_requested: bool = False
+    dismissal_settled: bool = False
+    superseded: bool = False
+    withheld_target: str | None = None
 
 
 def _map_event_code_to_alarm_type(event_code: str, alarm_type: str) -> bool:
@@ -218,6 +253,9 @@ class AbodeManualAlarmSwitch(AbodeAlarmAttachedEntity, SwitchEntity):
 
     _alarm_type: str
     _timeline_id: str | None = None
+    # Non-None only while a lookup may still be running: set when the task is
+    # created, cleared by the task's own unwind or by whoever cancels it.
+    _lookup: _EventIdLookup | None = None
 
     # Icon mapping for alarm types
     ALARM_ICONS = {
@@ -272,6 +310,15 @@ class AbodeManualAlarmSwitch(AbodeAlarmAttachedEntity, SwitchEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Clean up event subscriptions when removed."""
+        # Cancel first so the lookup stops early, but wait for it *after* the
+        # callbacks are gone: `_alarm_event_callback` / `_alarm_end_callback`
+        # both call `schedule_update_ha_state()`, and waiting here first would
+        # leave them registered against a half-torn-down entity for as long as
+        # the task takes to unwind.
+        lookup = self._lookup
+        self._cancel_event_id_lookup()
+        task = lookup.task if lookup is not None else None
+
         await super().async_will_remove_from_hass()
         await self._run_executor_with_timeout(
             self._data.abode.events.remove_event_callback,
@@ -283,6 +330,26 @@ class AbodeManualAlarmSwitch(AbodeAlarmAttachedEntity, SwitchEntity):
             TimelineGroups.ALARM_END,
             self._alarm_end_callback,
         )
+
+        if task is not None:
+            # `asyncio.wait` rather than `await task` under
+            # `suppress(CancelledError)`: that cannot tell the task's own
+            # cancellation from a cancellation of *this* coroutine, and would
+            # swallow the latter.
+            _, pending = await asyncio.wait(
+                {task}, timeout=EVENT_ID_TASK_TEARDOWN_SECONDS
+            )
+            if pending:
+                # Not expected to fire — the task only ever awaits network I/O
+                # and `asyncio.sleep`. If it does, the task outlives the entity
+                # and its next state write raises against a removed one, so say
+                # which entity so the two can be connected.
+                LOGGER.warning(
+                    "Event id lookup for the %s alarm did not unwind within "
+                    "%.0fs of being cancelled",
+                    self._alarm_type,
+                    EVENT_ID_TASK_TEARDOWN_SECONDS,
+                )
 
     def _alarm_event_callback(self, event: dict[str, Any]) -> None:
         """Handle alarm trigger events from timeline.
@@ -298,6 +365,18 @@ class AbodeManualAlarmSwitch(AbodeAlarmAttachedEntity, SwitchEntity):
         event_code = event.get("event_code", "")
         if not _map_event_code_to_alarm_type(event_code, self._alarm_type):
             return
+
+        # An ALARM event arriving after a dismissal was asked for disqualifies
+        # this ID as that dismissal's fallback *target*. It may be a genuinely new
+        # alarm or just our own alarm's late event — the payload cannot tell, and
+        # since deferral only happens when no ID had arrived yet, the late-event
+        # case is the likelier one. `dismiss_timeline_event` ignores one specific
+        # event, so guessing wrong the other way would silently swallow an alarm
+        # nobody has seen. The dismissal still goes out if the lookup finds its
+        # own event id.
+        lookup = self._lookup
+        if lookup is not None and lookup.dismissal_requested:
+            lookup.superseded = True
 
         # Update state when alarm is triggered
         self._timeline_id = event.get("id")
@@ -331,6 +410,12 @@ class AbodeManualAlarmSwitch(AbodeAlarmAttachedEntity, SwitchEntity):
         # When any alarm is dismissed, turn off all alarms
         # (since triggering one alarm dismisses all in Abode)
         self._timeline_id = None
+        # The alarm is over, so an in-flight event-ID lookup has nothing left to
+        # do — and a dismissal riding on it is now satisfied rather than
+        # abandoned: the alarm ending is what it was waiting for. Safe to cancel
+        # from here: timeline callbacks run on the event loop
+        # (`event_controller._execute_callback`).
+        self._cancel_event_id_lookup(settled=True)
         self._attr_is_on = False
         LOGGER.info(
             "Alarm %s ended via event (event_code: %s, all alarms dismissed)",
@@ -357,30 +442,294 @@ class AbodeManualAlarmSwitch(AbodeAlarmAttachedEntity, SwitchEntity):
                 },
             )
 
-        response = await self._alarm.trigger_manual_alarm(self._alarm_type)
-        # Safely extract event_id from response, handling non-dict responses
-        if isinstance(response, dict):
-            self._timeline_id = response.get("event_id")
-        else:
-            self._timeline_id = None
+        # Cleared *before* the POST, not after: the SocketIO ALARM event for
+        # this alarm can land while the request is still in flight, and
+        # `_alarm_event_callback`'s ID is the authoritative one. Anything still
+        # set at this point belongs to a previous alarm.
+        previous_timeline_id = self._timeline_id
+        was_resolving = self._lookup is not None
+        self._cancel_event_id_lookup()
+        self._timeline_id = None
 
-        LOGGER.info(
-            "Triggered manual alarm of type: %s (event_id: %s)",
-            self._alarm_type,
-            self._timeline_id,
-        )
+        try:
+            await self._alarm.trigger_manual_alarm(self._alarm_type)
+        except BaseException:
+            # No new alarm was raised, so nothing superseded the one this switch
+            # was already tracking. Leaving the ID cleared would strand a live
+            # alarm with no way to dismiss it — its SocketIO ALARM event fired
+            # long ago and will not repeat. BaseException, not Exception: a POST
+            # cancelled at shutdown strands the ID exactly the same way.
+            if self._timeline_id is None and self._attr_is_on:
+                self._timeline_id = previous_timeline_id
+            if self._timeline_id is None and was_resolving and self._attr_is_on:
+                # The cancelled lookup cannot be restored the way the ID can, so
+                # the previous alarm is now live with neither an ID nor anything
+                # still trying to find one. A 429 on a re-trigger inside the
+                # 30-67s resolution window is enough to get here, and without
+                # this the loss is invisible until someone tries to dismiss.
+                LOGGER.warning(
+                    "Re-triggering the %s alarm failed after its previous event "
+                    "id lookup was cancelled — the earlier alarm may still be "
+                    "live in Abode with no id to dismiss it",
+                    self._alarm_type,
+                )
+            raise
+
+        LOGGER.info("Triggered manual alarm of type: %s", self._alarm_type)
         self._attr_is_on = True
         self.async_write_ha_state()
+
+        # Resolving the timeline event ID polls Abode for up to ~67s (the API
+        # does not expose a triggered alarm on the timeline for 30-60s). It is
+        # only needed for a later dismissal, so it runs off the critical path —
+        # the alarm is already raised, and the `action_triggered` event that
+        # drives the user's notification fires as soon as this returns. See
+        # issue #194.
+        #
+        # An action wired to several alarm switches now polls once per switch on
+        # the same retry schedule, so those requests arrive together rather than
+        # spread out by the old inline serialization. The timeline endpoint has
+        # not shown the 429s the panel/CMS endpoints do; if it starts to, jitter
+        # belongs in `Alarm.timeline_event_retry_delays`, not here.
+        # Assigned before the task is created, not after: under eager start the
+        # coroutine can reach its `finally` first, and that clears `self._lookup`
+        # only when it still points at this lookup. Unwound on failure so a lookup
+        # that never ran cannot linger and make `was_resolving` lie.
+        lookup = _EventIdLookup()
+        self._lookup = lookup
+        try:
+            lookup.task = self.hass.async_create_background_task(
+                self._async_resolve_timeline_id(lookup),
+                name=f"abode_security resolve alarm event id {self._alarm_type}",
+            )
+        except BaseException:
+            if self._lookup is lookup:
+                self._lookup = None
+            raise
+
+    async def _async_resolve_timeline_id(self, lookup: _EventIdLookup) -> None:
+        """Resolve the timeline event ID, then store it or spend it dismissing."""
+        try:
+            event_id = await self._alarm.find_alarm_event_id()
+
+            if lookup.dismissal_requested:
+                # `async_turn_off` ran while this lookup was still in flight and
+                # handed the dismissal here rather than dropping it.
+                await self._async_send_dismissal(lookup, event_id)
+                return
+
+            if not event_id:
+                return
+
+            # Two ways this result can already be stale by the time it lands:
+            # `_alarm_event_callback` supplied the real ID over SocketIO (better
+            # source, keep it), or the alarm was dismissed/ended in the meantime
+            # (storing the ID would make the next `turn_off` dismiss an event
+            # that is already gone).
+            if not self._attr_is_on or self._timeline_id is not None:
+                LOGGER.debug(
+                    "Discarding polled event id %s for %s (is_on=%s, known id=%s)",
+                    event_id,
+                    self._alarm_type,
+                    self._attr_is_on,
+                    self._timeline_id,
+                )
+                return
+
+            self._timeline_id = event_id
+            LOGGER.info(
+                "Resolved timeline event id for %s alarm: %s",
+                self._alarm_type,
+                event_id,
+            )
+        finally:
+            # Every exit — resolved, gave up, dismissal sent, dismissal failed,
+            # cancelled by `_cancel_event_id_lookup`, or cancelled out of band by
+            # HA at shutdown — passes through here exactly once per task, and
+            # reports the lookup it was *handed* rather than whatever the entity
+            # currently points at. That is what makes "an abandoned dismissal is
+            # reported exactly once" hold by construction: a later cycle can
+            # replace `self._lookup`, but it cannot reach this one's obligation.
+            if self._lookup is lookup:
+                self._lookup = None
+            if lookup.dismissal_requested and not lookup.dismissal_settled:
+                # Names the withheld id and why: on the `superseded` path this
+                # warning is the only output, and the remedy is a manual dismissal.
+                LOGGER.warning(
+                    "The pending dismissal of the %s alarm was not sent — the "
+                    "alarm may still be live in Abode (superseded=%s, "
+                    "withheld id=%s)",
+                    self._alarm_type,
+                    lookup.superseded,
+                    lookup.withheld_target,
+                )
+
+    async def _async_send_dismissal(
+        self, lookup: _EventIdLookup, event_id: str | None
+    ) -> None:
+        """Send a dismissal `async_turn_off` could not send itself.
+
+        Runs inside the background lookup task, so it has no caller to raise to
+        and must consume its own errors — an escaping exception would surface
+        only as an unretrieved-task traceback. Anything short of success leaves
+        `lookup.dismissal_settled` false, and the caller's `finally` says so.
+        """
+        # The polled ID wins. Note what the poll does and does not guarantee:
+        # `_find_timeline_alarm_event` takes the newest `is_alarm` event aged
+        # `[0, 90]`s relative to its own start, so it cannot return an alarm
+        # raised *after* this lookup began, but a flat 90s backward bound means it
+        # can return an earlier one (see `features/pending.md`). `_timeline_id` is
+        # the fallback for a poll that came back empty on a transient error — and
+        # only while nothing newer has arrived, because `dismiss_timeline_event`
+        # ignores one specific event, and spending this dismissal on an alarm
+        # raised after the user asked for it would silently swallow one they have
+        # not seen.
+        target = event_id
+        if target is None:
+            if lookup.superseded:
+                lookup.withheld_target = self._timeline_id
+            else:
+                target = self._timeline_id
+        if not target:
+            return
+
+        try:
+            await self._data.abode.dismiss_timeline_event(target)
+        except Exception:
+            LOGGER.exception(
+                "Deferred dismissal of the %s alarm (timeline event %s) failed",
+                self._alarm_type,
+                target,
+            )
+            return
+
+        lookup.dismissal_settled = True
+        LOGGER.info("Dismissed timeline event: %s (deferred)", target)
+        # Reconcile: `_alarm_event_callback` may have flipped the switch back on
+        # and stored this ID during the deferral window. Waiting for ALARM_END to
+        # tidy up would leave the switch reporting a live alarm, holding an ID
+        # that now points at a dismissed event. Guarded, because that same
+        # callback may instead hold a *newer* alarm's ID, and its ALARM event
+        # will not repeat — clearing it would make that alarm undismissable.
+        if self._timeline_id in (None, target):
+            self._timeline_id = None
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        else:
+            # Mirrors the inline path's warning. "Your dismissal landed on an
+            # older event and a newer alarm is live" is the more confusing of the
+            # two outcomes, so it should not be the quieter one.
+            LOGGER.warning(
+                "Dismissed the %s alarm's earlier timeline event %s, but a newer "
+                "alarm (event %s) is live — leaving the switch on so it can still "
+                "be dismissed",
+                self._alarm_type,
+                target,
+                self._timeline_id,
+            )
+
+    def _cancel_event_id_lookup(self, *, settled: bool = False) -> None:
+        """Stop the in-flight event-ID lookup.
+
+        `settled` when whatever a pending dismissal was waiting for has already
+        happened. Settling the obligation is the *only* thing that keeps the
+        abandoned-dismissal warning off the benign paths; every other caller
+        leaves it outstanding and the owning task reports it as it unwinds.
+
+        Two callers pass it, and they know it to different degrees. `ALARM_END`
+        knows it: Abode said the alarm is over. The inline branch of
+        `async_turn_off` is making a judgement — it just dismissed the ID now on
+        the entity, and treats that as discharging an earlier request for which no
+        ID had arrived. In that situation the lookup is necessarily `superseded`
+        (only `_alarm_event_callback` can put an ID there while a dismissal is
+        outstanding, and it sets that flag), so this settles on exactly the
+        ambiguity `_async_send_dismissal` refuses to resolve. The asymmetry is
+        deliberate: deferral only happens when no ID had arrived, which makes the
+        late-own-event reading the likely one, and warning here would fire on that
+        common path — the false alarm that makes the real warnings worthless. The
+        cost is that the rarer reading (a genuinely different alarm) settles an
+        obligation that was not actually met, silently. `dismiss_timeline_event`
+        ignoring one specific event is what makes both readings survivable: the
+        other alarm keeps its own ID and stays dismissable.
+        """
+        lookup = self._lookup
+        if lookup is None:
+            return
+
+        if settled:
+            lookup.dismissal_settled = True
+        self._lookup = None
+
+        task = lookup.task
+        if task is not None and not task.done():
+            task.cancel()
 
     @handle_abode_errors("dismiss timeline event")
     async def async_turn_off(self, **_kwargs: Any) -> None:
         """Dismiss the manual alarm (if timeline event ID is available)."""
+        lookup = self._lookup
+        superseded_by: str | None = None
         if self._timeline_id:
-            await self._data.abode.dismiss_timeline_event(self._timeline_id)
-            LOGGER.info("Dismissed timeline event: %s", self._timeline_id)
-            self._timeline_id = None
+            # Captured before the await, and logged from the capture: reading the
+            # attribute back afterwards can name an event that was never
+            # dismissed, on a path where the log is the audit trail.
+            target = self._timeline_id
+            await self._data.abode.dismiss_timeline_event(target)
+            LOGGER.info("Dismissed timeline event: %s", target)
+            # Settles any dismissal riding on the lookup: what it was waiting to
+            # do has just been done. Reached only *after* the await — a failed
+            # inline dismissal raises through `handle_abode_errors` and leaves the
+            # obligation outstanding as a fallback.
+            self._cancel_event_id_lookup(settled=True)
+            # Same reconciliation rule as the deferred path: only clear what was
+            # actually dismissed. `_alarm_event_callback` can fire during the
+            # await with a *newer* alarm's id, and that alarm's ALARM event will
+            # not repeat — clearing it would make it undismissable, and reporting
+            # the switch off would hide it.
+            if self._timeline_id in (None, target):
+                self._timeline_id = None
+            else:
+                superseded_by = self._timeline_id
+        elif lookup is not None and lookup.dismissal_requested:
+            LOGGER.info(
+                "A dismissal of the %s alarm is already pending on its event id lookup",
+                self._alarm_type,
+            )
+        elif lookup is not None and lookup.task is not None:
+            # The ID is still being resolved. Waiting for it here is the wrong
+            # trade twice over: Abode typically needs 30-60s to expose the event
+            # at all, and `PARALLEL_UPDATES = 1` means a blocked `turn_off`
+            # serializes every other Abode switch call behind it — including the
+            # `switch.turn_on` that raises the *next* alarm, which is exactly the
+            # latency #194 set out to remove. So the dismissal is handed to the
+            # lookup instead, and sent the moment the ID lands.
+            lookup.dismissal_requested = True
+            LOGGER.info(
+                "No timeline event id for the %s alarm yet; the dismissal will "
+                "be sent to Abode as soon as the lookup resolves",
+                self._alarm_type,
+            )
+        elif self._attr_is_on:
+            # Not silent: the switch is about to report off while the alarm may
+            # still be live in Abode, and that is a security path. Reachable when
+            # neither the SocketIO ALARM event nor the timeline poll ever
+            # produced an ID.
+            LOGGER.warning(
+                "No timeline event id for the %s alarm — nothing was dismissed "
+                "in Abode; the switch is reporting off regardless",
+                self._alarm_type,
+            )
 
-        self._attr_is_on = False
+        if superseded_by is None:
+            self._attr_is_on = False
+        else:
+            LOGGER.warning(
+                "A new %s alarm (timeline event %s) was raised while the previous "
+                "one was being dismissed — leaving the switch on so it can still "
+                "be dismissed",
+                self._alarm_type,
+                superseded_by,
+            )
         self.async_write_ha_state()
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,6 +158,75 @@ Such records are deliberately **not** disabled at load either — a failing acti
 which is the only signal the user gets during the incident; the startup repair issue makes
 sure it isn't silent.
 
+##### Event-ID resolution and deferred dismissal
+
+Raising the alarm is the `POST /integrations/v1/panel/alarm`; the timeline event ID is only
+needed later, to *dismiss* it. Abode does not expose a triggered alarm on the timeline for
+30-60 s, so `Alarm._find_timeline_alarm_event` polls on a `(0, 2, 5, 10, 20, 30)` backoff —
+67 s in the worst case. That poll used to run inline inside `trigger_manual_alarm`, which
+put it in front of `async_arm_alarm`, `_execute_action`, and therefore the
+`action_triggered` event that drives the user's notification: a "call the police" action
+notified 30-70 s after the break-in (#194).
+
+`trigger_manual_alarm` now returns as soon as the POST is confirmed. The poll lives in
+`Alarm.find_alarm_event_id()` (best-effort, never raises except `CancelledError`), which
+`AbodeManualAlarmSwitch.async_turn_on` runs as an HA background task.
+
+The ID has two sources and SocketIO is the authoritative one: `_alarm_event_callback` sets
+`_timeline_id` when the `TimelineGroups.ALARM` event arrives, and the poll is the fallback
+for when it does not. `async_turn_on` therefore clears `_timeline_id` *before* the POST, and
+the poll result is discarded if SocketIO already supplied one.
+
+Dismissal is what backgrounding put at risk, since `switch.turn_off` inside the resolution
+window finds no ID. `async_turn_off` does not wait for one — the poll usually needs the full
+30-60 s, and `PARALLEL_UPDATES = 1` means a blocked `turn_off` serializes the `switch.turn_on`
+that raises the *next* alarm. Instead it marks the dismissal as owed on the lookup, and the
+background task sends it once the ID lands.
+
+That obligation is an `_EventIdLookup` — one object per lookup run, **handed to the task that
+performs it** rather than left in entity state a later alarm cycle can overwrite. The task
+reports an unsent dismissal from its own `finally`, reading the object it was given, so
+"an abandoned dismissal is reported exactly once" holds by construction: one lookup per task,
+one `finally` per task, no identity checks, and no verdict that has to survive an await.
+`_cancel_event_id_lookup(settled=True)` marks the obligation settled before cancelling (the
+alarm ended, or was just dismissed inline); every other caller leaves it outstanding, and a
+cancellation that bypasses the helper entirely — HA stopping its background tasks at
+shutdown — is covered by the same `finally` for free.
+
+Which event the deferred dismissal targets is a deliberate choice, because
+`dismiss_timeline_event` ignores one *specific* event (`POST timeline_ignore_alarm/<id>`). The
+polled ID wins, and `_timeline_id` is only the fallback for a poll that came back empty on a
+transient error — and then only while nothing newer has arrived. A `TimelineGroups.ALARM` event
+landing after the dismissal was asked for may be a *new* alarm rather than a late event for
+ours, and the payload cannot tell them apart, so it marks the lookup `superseded` and the
+fallback is withdrawn. Failing to dismiss is loud and recoverable; silently ignoring an alarm
+nobody has seen is neither.
+
+
+Settling an obligation has one asymmetry worth knowing. `ALARM_END` settles it on fact — Abode
+said the alarm is over. The inline branch of `async_turn_off` settles it on a judgement: it
+just dismissed the ID now on the entity, and treats that as discharging an earlier request for
+which no ID had arrived. In that situation the lookup is necessarily `superseded`, so this
+resolves the same ambiguity `_async_send_dismissal` refuses to resolve, and in the opposite
+direction. That is deliberate — deferral only happens when no ID had arrived, which makes the
+late-own-event reading the likely one, and warning there would fire on the common path. The
+accepted cost is that the rarer reading settles an obligation that was not met, silently;
+per-event dismissal semantics are what make both readings survivable, since the other alarm
+keeps its own ID.
+
+What the poll guarantees is narrower than "the event this lookup triggered", and the ordering
+above should not be read as more: `_find_timeline_alarm_event` accepts the newest event with
+`is_alarm == '1'` whose age falls in `[0, 90]` seconds relative to the lookup's own start. The
+forward bound is what makes it safe against the new-alarm case — a later alarm has a negative
+age and is skipped. The backward bound is a flat 90 s, so a second alarm raised while the
+first is still surfacing can be handed the first one's ID. Bounding that window against
+elapsed lookup time is tracked in `features/pending.md`.
+
+An earlier revision split this across three booleans on the entity, read from three reporting
+sites. It took several rounds of review to stabilise and each fix exposed another instance of
+the same bug class — entity-scoped state written by more than one owner across an await. The
+handed-to-the-owner shape is the same behaviour with that class of bug made unrepresentable.
+
 ### Actions system (`action_manager.py`, `action_trigger.py`)
 
 User-defined mappings from **sensor activation → event fire (and optionally an alarm trigger)**, gated by alarm mode.
@@ -171,7 +240,7 @@ The `abode_security.action_triggered` event payload carries 19 keys: the origina
 
 `alarm_outcome` (`armed` / `partial` / `failed` / `none`) and `severity` (`critical` / `high` / `normal`) exist because `alarms_triggered` and `alarms_failed` shipped from the start and nothing ever read them: an action whose alarm was rejected by the API produced a notification identical to a successful one. Severity is computed in the integration (`action_trigger._severity`) rather than in the blueprint so custom automations escalate the same way, and a *failed* alarm is rated `critical` — the user believes monitoring was contacted when it was not. `_execute_action` also verifies rather than assumes, but only *before* the call: `async_arm_alarm` checks the target entity is in the `switch` domain, exists, and is available, because HA drops out-of-domain, missing, and unavailable entities from an entity service call and only logs it (`helpers/service.py`), and Abode entities go unavailable whenever the SocketIO stream drops. (The domain check matters because `cv.entity_id` on the WebSocket schemas validates the `domain.object_id` *format* only — a stored action naming `light.porch` would otherwise pass every guard and be recorded as armed.) A returning service call is then taken as success.
 
-There is deliberately **no** post-call state check. Two were tried and both reported successfully raised alarms as failures: re-reading on/off races `_alarm_end_callback`, which clears `_attr_is_on` on every manual alarm switch; and re-reading availability is poisoned by `async_turn_on`'s own closing `async_write_ha_state()`, which stamps `unavailable` if availability flipped at any point during a call that blocks for the inline timeline lookup (67 s of retry delays — see #194). The residual sub-millisecond window between the pre-check and HA's own filter errs toward `armed`, which is the correct direction against a ~70 s false-failure window.
+There is deliberately **no** post-call state check. Two were tried and both reported successfully raised alarms as failures: re-reading on/off races `_alarm_end_callback`, which clears `_attr_is_on` on every manual alarm switch; and re-reading availability is poisoned by `async_turn_on`'s own closing `async_write_ha_state()`, which stamps `unavailable` if availability flipped at any point during the call. That window was ~70 s wide until #194 moved the timeline lookup off this path and is now roughly one round-trip, but the race survives. The residual sub-millisecond window between the pre-check and HA's own filter errs toward `armed`, which is the correct direction against reporting a raised alarm as failed.
 
 Failures raise a per-action repair issue via `action_repair.py` and are persisted as `AbodeAction.last_outcome` so the Actions panel can badge them.
 

--- a/features/pending.md
+++ b/features/pending.md
@@ -72,6 +72,28 @@ The frontend panel (`frontend/src/abode-panel.ts`) currently implements Actions 
 - [ ] **E2E scenario tests** (~10 tests) - Full workflow testing — could use mock server approach
 - [ ] **Integration advanced features tests** (~18 tests) — require options flow and complex setup
 
+## Abode API
+
+**Source**: review of #194
+
+- [ ] **Bound `_find_timeline_alarm_event`'s backward recency window against elapsed
+  lookup time.** It accepts the newest `is_alarm == '1'` event whose age is in
+  `[0, 90]` seconds relative to the lookup's start. The forward bound is what keeps a
+  *newer* alarm from being matched; the backward bound is a flat 90 s, so a second
+  alarm raised while the first is still surfacing on the timeline can be handed the
+  first one's event ID. Passing the trigger timestamp down and narrowing the window to
+  roughly the elapsed poll time would close it. Only affects which event a *dismissal*
+  targets, never whether an alarm is raised.
+
+- [ ] **Resolve which dismissal semantics Abode actually has.** Two comments in
+  `switch.py` are in tension: `_alarm_end_callback` says "triggering one alarm dismisses
+  all in Abode" (pre-existing, and why it turns off every manual alarm switch), while
+  `_async_send_dismissal` and `async_turn_off` reason from the HTTP layer, where
+  `dismiss_timeline_event` is `POST timeline_ignore_alarm/<id>` — one specific event. If
+  the first is true, the deferred path's `superseded` conservatism is unnecessary; if the
+  second is, the `_alarm_end_callback` fan-off is over-broad. Needs a check against a live
+  panel; neither comment should be treated as established until then.
+
 ## CI/CD Improvements
 
 **Source**: Phase 7 of better-development

--- a/tests/test_manual_alarm_trigger.py
+++ b/tests/test_manual_alarm_trigger.py
@@ -8,11 +8,17 @@ fail on all ten of its real triggers while the whole suite stayed green.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import logging
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
+from custom_components.abode_security import switch as switch_module
 from custom_components.abode_security.abode.exceptions import (
     Exception as AbodeException,
 )
@@ -34,12 +40,55 @@ def _make_switch(alarm_type: str) -> tuple[AbodeManualAlarmSwitch, MagicMock]:
     alarm.id = "area_1"
     alarm.type = "Alarm"
     alarm.name = "Abode Alarm"
-    alarm.trigger_manual_alarm = AsyncMock(return_value={"event_id": "tl_1"})
+    alarm.trigger_manual_alarm = AsyncMock(return_value={"code": 200})
+    alarm.find_alarm_event_id = AsyncMock(return_value="tl_1")
     data = MagicMock()
     data.polling = False
+    data.abode.dismiss_timeline_event = AsyncMock()
     switch = AbodeManualAlarmSwitch(data, alarm, alarm_type)
     switch.async_write_ha_state = MagicMock()
+    switch.schedule_update_ha_state = MagicMock()
+    switch.hass = cast(HomeAssistant, _FakeHass())
     return switch, alarm
+
+
+class _FakeHass:
+    """Just enough `hass` for the background event-id lookup.
+
+    `async_create_background_task` has to produce a *real* task so tests can
+    await the lookup instead of asserting against a MagicMock that never ran.
+    """
+
+    def __init__(self) -> None:
+        self.tasks: list[asyncio.Task[Any]] = []
+
+    def async_create_background_task(
+        self, target: Any, name: str, eager_start: bool = True
+    ) -> asyncio.Task[Any]:
+        # Eager, matching HA's default. The hazard is real but narrower than it
+        # looks: a task cancelled before it starts never runs its body, and so
+        # never its `finally` — but most tests here `gather` the task, so the
+        # body runs eventually either way. Measured, exactly one assertion
+        # depends on eagerness — `test_retrigger_over_a_deferred_dismissal_is_
+        # logged`, where a re-trigger cancels a displaced lookup that must
+        # already have entered its body — and it is the only test that fails
+        # under a non-eager harness. Keep it anyway: eager start still suspends
+        # at the first `await`, so it costs nothing and matches production.
+        del name
+        task = asyncio.get_running_loop().create_task(target, eager_start=eager_start)
+        self.tasks.append(task)
+        return task
+
+    async def async_add_executor_job(self, fn: Any, *args: Any) -> Any:
+        return fn(*args)
+
+
+def _tasks(switch: AbodeManualAlarmSwitch) -> list[asyncio.Task[Any]]:
+    return cast(_FakeHass, switch.hass).tasks
+
+
+def _dismiss_mock(switch: AbodeManualAlarmSwitch) -> AsyncMock:
+    return cast(AsyncMock, switch._data.abode.dismiss_timeline_event)
 
 
 @pytest.mark.parametrize("alarm_type", sorted(TRIGGERABLE_ALARM_TYPES))
@@ -104,6 +153,39 @@ async def test_repeat_trigger_is_not_suppressed() -> None:
     assert alarm.trigger_manual_alarm.await_count == 2
 
 
+def _make_api_alarm():
+    """A real `Alarm` whose POST succeeds, with no client behind it."""
+    from custom_components.abode_security.abode.devices.alarm import Alarm
+
+    # Stateful.__getattr__ resolves through self._state, so that has to exist
+    # before any attribute access or the lookup recurses.
+    alarm = Alarm({"id": "area_1"}, MagicMock())
+
+    response = MagicMock()
+    response.text = AsyncMock(return_value="{}")
+    response.json = AsyncMock(return_value={"code": 200})
+    alarm._client.send_request = AsyncMock(return_value=response)
+    return alarm
+
+
+async def test_trigger_returns_without_the_timeline_lookup() -> None:
+    """The POST is the alarm; the event-id lookup must not be on that path.
+
+    `trigger_manual_alarm` used to poll the timeline inline for up to ~67s
+    (`timeline_event_retry_delays` sums to 67) *after* the POST had already
+    raised the alarm and notified monitoring. Everything downstream — the
+    switch, the actions executor, the `action_triggered` event that drives the
+    user's notification — waited that out. See issue #194.
+    """
+    alarm = _make_api_alarm()
+    alarm._find_timeline_alarm_event = AsyncMock(return_value="tl_1")
+
+    result = await alarm.trigger_manual_alarm("PANIC")
+
+    assert result["code"] == 200
+    alarm._find_timeline_alarm_event.assert_not_awaited()
+
+
 @pytest.mark.parametrize(
     "boom",
     [
@@ -115,31 +197,864 @@ async def test_repeat_trigger_is_not_suppressed() -> None:
 async def test_timeline_lookup_failure_cannot_undo_a_raised_alarm(boom) -> None:
     """A raised alarm must never be reported as a failure.
 
-    `trigger_manual_alarm` POSTs, confirms code 200 — at which point the alarm
-    IS raised and monitoring HAS been contacted — and only then polls the
-    timeline for an event id, for up to ~67 seconds. `alarm.py` shadows the
-    builtin `Exception` with the Abode one, so the guard inside
+    `find_alarm_event_id` runs after the alarm is already raised and monitoring
+    already contacted, and polls for up to ~67 seconds — so a transient network
+    error inside it is entirely plausible. `alarm.py` shadows the builtin
+    `Exception` with the Abode one, so the guard inside
     `_find_timeline_alarm_event` does not catch TimeoutError/OSError/ValueError.
-    Letting those escape would make the executor record `alarms_failed` and
-    fire a critical "no alarm was raised" notification for an alarm that was,
-    in fact, raised.
+    Letting those escape would surface as an unretrieved background-task
+    traceback, and back when this ran inline it made the executor record
+    `alarms_failed` and fire a critical "no alarm was raised" notification for
+    an alarm that was, in fact, raised.
     """
-    from custom_components.abode_security.abode.devices.alarm import Alarm
-
-    # Stateful.__getattr__ resolves through self._state, so that has to exist
-    # before any attribute access or the lookup recurses.
-    alarm = Alarm({"id": "area_1"}, MagicMock())
-
-    response = MagicMock()
-    response.text = AsyncMock(return_value="{}")
-    response.json = AsyncMock(return_value={"code": 200})
-    alarm._client.send_request = AsyncMock(return_value=response)
+    alarm = _make_api_alarm()
     alarm._find_timeline_alarm_event = AsyncMock(side_effect=boom)
 
-    result = await alarm.trigger_manual_alarm("PANIC")
+    assert await alarm.find_alarm_event_id() is None
 
-    assert result["code"] == 200
-    assert result.get("event_id") is None
+
+async def test_cancellation_escapes_the_lookup_guard() -> None:
+    """The one exception `find_alarm_event_id` must *not* swallow.
+
+    The abandoned-dismissal report hangs off `CancelledError` reaching the
+    switch's `finally`. Widening the guard to `except BaseException` would
+    silence it with the rest of the suite still green.
+    """
+    alarm = _make_api_alarm()
+    alarm._find_timeline_alarm_event = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with pytest.raises(asyncio.CancelledError):
+        await alarm.find_alarm_event_id()
+
+
+async def test_turn_on_does_not_wait_for_the_event_id() -> None:
+    """The whole point of #194: notification latency, not lookup completeness."""
+    switch, alarm = _make_switch("PANIC")
+    release = asyncio.Event()
+
+    async def _slow_lookup() -> str:
+        await release.wait()
+        return "tl_1"
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_slow_lookup)
+
+    await asyncio.wait_for(switch.async_turn_on(), timeout=1)
+
+    assert switch.is_on is True
+    assert switch._timeline_id is None
+
+    release.set()
+    await asyncio.gather(*_tasks(switch))
+    assert switch._timeline_id == "tl_1"
+
+
+async def test_socketio_event_id_wins_over_the_background_lookup() -> None:
+    """`_alarm_event_callback` is the primary source; the poll is the fallback.
+
+    The callback fires on the SocketIO timeline event, which can land while the
+    POST is still in flight. Its id is the authoritative one, so a later-landing
+    poll result must not overwrite it.
+    """
+    switch, alarm = _make_switch("PANIC")
+
+    async def _lookup() -> str:
+        switch._alarm_event_callback(
+            {"is_alarm": "1", "event_code": "1120", "id": "tl_socketio"}
+        )
+        return "tl_polled"
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_lookup)
+
+    await switch.async_turn_on()
+    await asyncio.gather(*_tasks(switch))
+
+    assert switch._timeline_id == "tl_socketio"
+
+
+async def test_background_lookup_does_not_resurrect_an_ended_alarm() -> None:
+    """An id landing after the alarm ended is stale — it must not be stored.
+
+    Otherwise the next `turn_off` would dismiss an event that is already gone.
+    """
+    switch, alarm = _make_switch("PANIC")
+    release = asyncio.Event()
+
+    async def _slow_lookup() -> str:
+        await release.wait()
+        return "tl_1"
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_slow_lookup)
+
+    await switch.async_turn_on()
+    switch._alarm_end_callback({"event_code": "3120"})
+
+    release.set()
+    await asyncio.gather(*_tasks(switch), return_exceptions=True)
+
+    assert switch.is_on is False
+    assert switch._timeline_id is None
+
+
+async def test_dismiss_with_a_resolved_event_id_dismisses_inline() -> None:
+    """The primary dismissal path: the ID is already known, so just send it."""
+    switch, _ = _make_switch("PANIC")
+
+    await switch.async_turn_on()
+    await asyncio.gather(*_tasks(switch))
+    assert switch._timeline_id == "tl_1"
+
+    await switch.async_turn_off()
+
+    _dismiss_mock(switch).assert_awaited_once_with("tl_1")
+    assert switch.is_on is False
+    assert switch._timeline_id is None
+
+
+async def test_lookup_finding_nothing_leaves_no_event_id() -> None:
+    """No ID and no dismissal pending: nothing to store, nothing to dismiss."""
+    switch, alarm = _make_switch("PANIC")
+    alarm.find_alarm_event_id = AsyncMock(return_value=None)
+
+    await switch.async_turn_on()
+    await asyncio.gather(*_tasks(switch))
+
+    assert switch._timeline_id is None
+    assert switch.is_on is True
+
+
+async def test_a_newer_alarm_is_not_dismissed_by_an_older_request(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A deferred dismissal must not be spent on an alarm it was not asked about.
+
+    `_timeline_id` is the fallback target when the poll comes back empty, but the
+    deferral window is 30-67s wide and a `TimelineGroups.ALARM` event landing
+    inside it may be a *new* alarm rather than a late event for ours — the payload
+    cannot tell them apart. `dismiss_timeline_event` ignores one specific event,
+    so using it here would silently suppress an alarm nobody has seen.
+
+    The deliberate trade: fail to dismiss, loudly, rather than silently swallow a
+    live alarm. The new alarm stays visible (`is_on` back to True) and remains
+    dismissable via its own id.
+    """
+    switch, alarm = _make_switch("PANIC")
+    release = asyncio.Event()
+
+    async def _lookup_that_finds_nothing() -> None:
+        await release.wait()
+        return None
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_lookup_that_finds_nothing)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+
+    switch._alarm_event_callback(
+        {"is_alarm": "1", "event_code": "1120", "id": "tl_new_alarm"}
+    )
+    release.set()
+    with caplog.at_level(logging.WARNING):
+        await asyncio.gather(*_tasks(switch))
+
+    _dismiss_mock(switch).assert_not_awaited()
+    assert switch._timeline_id == "tl_new_alarm"
+    assert switch.is_on is True
+    assert _warnings(caplog) == [
+        _unsent_warning(superseded=True, withheld="tl_new_alarm")
+    ]
+
+
+async def test_deferred_dismissal_uses_the_id_the_lookup_found() -> None:
+    """The polled id is the one this lookup verifiably found; it wins.
+
+    A stale `_timeline_id` from an earlier alarm must not redirect the dismissal.
+    """
+    switch, alarm = _make_switch("PANIC")
+    release = asyncio.Event()
+
+    async def _slow_lookup() -> str:
+        await release.wait()
+        return "tl_polled"
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_slow_lookup)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+    switch._timeline_id = "tl_stale"
+
+    release.set()
+    await asyncio.gather(*_tasks(switch))
+
+    _dismiss_mock(switch).assert_awaited_once_with("tl_polled")
+    # A different id was live, so the reconcile leaves it alone.
+    assert switch._timeline_id == "tl_stale"
+
+
+async def test_inline_dismissal_does_not_clobber_a_newer_alarm(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Same reconciliation rule as the deferred path, one round-trip wide.
+
+    `_alarm_event_callback` can fire during the dismissal POST with a new alarm of
+    the same type. Its ALARM event will not repeat, so clearing `_timeline_id`
+    would make it undismissable — and reporting the switch off would hide it.
+    """
+    switch, alarm = _make_switch("PANIC")
+    await switch.async_turn_on()
+    await asyncio.gather(*_tasks(switch))
+    assert switch._timeline_id == "tl_1"
+
+    async def _new_alarm_lands_mid_request(_event_id: str) -> None:
+        switch._alarm_event_callback(
+            {"is_alarm": "1", "event_code": "1120", "id": "tl_newer"}
+        )
+
+    _dismiss_mock(switch).side_effect = _new_alarm_lands_mid_request
+
+    with caplog.at_level(logging.INFO):
+        await switch.async_turn_off()
+
+    # The original event was dismissed, and the log names *it* rather than the
+    # id that happened to be on the instance afterwards.
+    _dismiss_mock(switch).assert_awaited_once_with("tl_1")
+    assert any(
+        record.getMessage() == "Dismissed timeline event: tl_1"
+        for record in caplog.records
+    )
+    # The newer alarm survives, both as an id and as switch state.
+    assert switch._timeline_id == "tl_newer"
+    assert switch.is_on is True
+    assert any("was raised while the previous one" in m for m in _warnings(caplog))
+
+
+async def test_superseded_still_dismisses_when_the_poll_finds_its_own_event() -> None:
+    """`superseded` withdraws the *fallback*, not the dismissal.
+
+    A new alarm arriving after the request disqualifies `_timeline_id` as a
+    target, but if the lookup finds the event it was actually looking for, the
+    user's dismissal still goes out — and the new alarm is left alone.
+    """
+    switch, alarm = _make_switch("PANIC")
+    release = asyncio.Event()
+
+    async def _slow_lookup() -> str:
+        await release.wait()
+        return "tl_ours"
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_slow_lookup)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+    switch._alarm_event_callback(
+        {"is_alarm": "1", "event_code": "1120", "id": "tl_new_alarm"}
+    )
+    assert switch._lookup is not None and switch._lookup.superseded is True
+
+    release.set()
+    await asyncio.gather(*_tasks(switch))
+
+    _dismiss_mock(switch).assert_awaited_once_with("tl_ours")
+    assert switch._timeline_id == "tl_new_alarm"
+    assert switch.is_on is True
+
+
+async def test_inline_dismissal_settles_an_earlier_superseded_request(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Naming the one place an unmet obligation is settled on a judgement.
+
+    Sequence: alarm raised → `turn_off` defers (no id yet) → an ALARM event
+    arrives, which marks the lookup `superseded` and revives the switch → the user
+    turns off again, dismissing the id now on the entity. That inline dismissal
+    settles the earlier request, on the reading that the ALARM event was our own
+    alarm's late event — which is the likely one, since deferral only happens when
+    no id had arrived.
+
+    It stays quiet deliberately: warning here would fire on the common path and
+    devalue the real warnings. The cost, accepted, is that the rarer reading (a
+    genuinely different alarm) settles an obligation that was not met. Both
+    readings survive because `dismiss_timeline_event` ignores one specific event,
+    so the other alarm keeps its own id.
+    """
+    switch, alarm = _make_switch("PANIC")
+    alarm.find_alarm_event_id = AsyncMock(side_effect=asyncio.Event().wait)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+    lookup = switch._lookup
+    assert lookup is not None and lookup.dismissal_requested
+
+    switch._alarm_event_callback(
+        {"is_alarm": "1", "event_code": "1120", "id": "tl_arrived"}
+    )
+    assert lookup.superseded is True
+
+    with caplog.at_level(logging.WARNING):
+        await switch.async_turn_off()
+        await asyncio.gather(*_tasks(switch), return_exceptions=True)
+
+    _dismiss_mock(switch).assert_awaited_once_with("tl_arrived")
+    assert lookup.dismissal_settled is True
+    assert _warnings(caplog) == []
+
+
+async def test_second_dismiss_after_socketio_revives_the_switch_is_quiet(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A satisfied deferral must not warn that the alarm may still be live.
+
+    Sequence: dismiss inside the lookup window (deferred) → the SocketIO ALARM
+    event lands 30-60s later and flips the switch visibly back on → the user
+    turns it off again, now with an ID in hand. The inline dismissal succeeds,
+    so the deferral is satisfied; warning here would train operators to
+    discount the warning that means something.
+    """
+    switch, alarm = _make_switch("PANIC")
+    alarm.find_alarm_event_id = AsyncMock(side_effect=asyncio.Event().wait)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+    assert switch._lookup is not None and switch._lookup.dismissal_requested
+
+    switch._alarm_event_callback(
+        {"is_alarm": "1", "event_code": "1120", "id": "tl_socketio"}
+    )
+    assert switch.is_on is True
+
+    with caplog.at_level(logging.WARNING):
+        await switch.async_turn_off()
+
+    _dismiss_mock(switch).assert_awaited_once_with("tl_socketio")
+    assert switch.is_on is False
+    assert not (switch._lookup is not None and switch._lookup.dismissal_requested)
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ] == []
+    await asyncio.gather(*_tasks(switch), return_exceptions=True)
+
+
+def _dismiss_that_blocks(gate: asyncio.Event) -> Any:
+    """A `dismiss_timeline_event` that parks with the request "on the wire"."""
+
+    async def _hang(_event_id: str) -> None:
+        gate.set()
+        await asyncio.Event().wait()
+
+    return _hang
+
+
+async def _park_in_flight_dismissal(
+    switch: AbodeManualAlarmSwitch, alarm: MagicMock
+) -> asyncio.Task[Any]:
+    """Get the switch to a deferred dismissal that is mid-request.
+
+    The lookup has to actually suspend for `turn_off` to defer rather than
+    dismiss inline — which is the real shape, since Abode needs 30-60s to expose
+    the event, and the default `AsyncMock` resolving instantly is the artifact.
+    """
+    release = asyncio.Event()
+    in_flight = asyncio.Event()
+
+    async def _slow_lookup() -> str:
+        await release.wait()
+        return "tl_1"
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_slow_lookup)
+    _dismiss_mock(switch).side_effect = _dismiss_that_blocks(in_flight)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+    task = _tasks(switch)[-1]
+    assert switch._lookup is not None and switch._lookup.dismissal_requested
+
+    release.set()
+    await in_flight.wait()
+    return task
+
+
+def _unsent_warning(*, superseded: bool = False, withheld: str | None = None) -> str:
+    """The sole abandoned-dismissal warning, rendered."""
+    return (
+        "The pending dismissal of the PANIC alarm was not sent — the alarm may "
+        f"still be live in Abode (superseded={superseded}, withheld id={withheld})"
+    )
+
+
+def _warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ]
+
+
+async def test_alarm_end_during_an_in_flight_dismissal_is_quiet(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """ALARM_END beating our own dismissal response is an ordinary outcome.
+
+    Abode broadcasts the end over SocketIO while processing the very POST we
+    are waiting on, so the push routinely wins the race. Warning that the alarm
+    "may still be live" immediately after being told it ended is exactly the
+    false alarm that devalues the true ones.
+    """
+    switch, alarm = _make_switch("PANIC")
+    task = await _park_in_flight_dismissal(switch, alarm)
+
+    with caplog.at_level(logging.WARNING):
+        switch._alarm_end_callback({"event_code": "3120"})
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert task.cancelled()
+    assert _warnings(caplog) == []
+
+
+async def test_a_later_cancel_does_not_relabel_an_already_settled_dismissal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Only the cancel that did the work gets to judge it moot or lost.
+
+    Operator dismisses, Abode reports the alarm ended, operator re-panics. The
+    ALARM_END already settled that dismissal as moot; the re-trigger's cancel
+    finds no task left and must not relabel it — otherwise the sequence warns
+    twice that an alarm Abode just told us ended may still be live.
+    """
+    switch, alarm = _make_switch("PANIC")
+    task = await _park_in_flight_dismissal(switch, alarm)
+
+    with caplog.at_level(logging.WARNING):
+        switch._alarm_end_callback({"event_code": "3120"})
+        await switch.async_turn_on()
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert _warnings(caplog) == []
+
+
+async def test_settling_one_cycle_does_not_silence_the_next(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Settled-ness belongs to the lookup it settled, not to the entity.
+
+    Cycle 1's dismissal is settled by ALARM_END. Cycle 2 raises a fresh alarm
+    whose dismissal is then cancelled out of band — HA stopping its background
+    tasks at shutdown, which never reaches `async_will_remove_from_hass`. That one
+    really is lost, and any entity-scoped "already settled" state left over from
+    cycle 1 would silence it.
+    """
+    switch, alarm = _make_switch("PANIC")
+    first = await _park_in_flight_dismissal(switch, alarm)
+    switch._alarm_end_callback({"event_code": "3120"})
+    await asyncio.gather(first, return_exceptions=True)
+
+    second = await _park_in_flight_dismissal(switch, alarm)
+    assert second is not first
+
+    with caplog.at_level(logging.WARNING):
+        second.cancel()
+        await asyncio.gather(second, return_exceptions=True)
+
+    assert _warnings(caplog) == [_unsent_warning()]
+
+
+async def test_out_of_band_cancel_while_armed_is_still_reported(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Shutdown can cancel the task without going through the cancel helper.
+
+    While the dismissal is armed but not yet on the wire, neither
+    `_cancel_event_id_lookup` nor the dismissal's own handler would see it —
+    the operator would lose the only signal that an alarm may still be live.
+    """
+    switch, alarm = _make_switch("PANIC")
+    polling = asyncio.Event()
+
+    async def _park_polling() -> None:
+        polling.set()
+        await asyncio.Event().wait()
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_park_polling)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+    assert switch._lookup is not None and switch._lookup.dismissal_requested
+    task = _tasks(switch)[0]
+    await polling.wait()
+
+    with caplog.at_level(logging.WARNING):
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert _warnings(caplog) == [_unsent_warning()]
+
+
+async def test_a_displaced_lookup_still_reports_its_own_dismissal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A cancelled lookup owns its obligation all the way to its `finally`.
+
+    A cancelled task runs its `finally` a loop iteration later, and a re-trigger
+    plus `turn_off` in that gap installs a *new* lookup. The old one must still
+    report the dismissal it was carrying — reading a shared slot would find the
+    replacement and report nothing at all — and the new one must be armed.
+    """
+    switch, alarm = _make_switch("PANIC")
+    first = await _park_in_flight_dismissal(switch, alarm)
+
+    # Re-trigger and dismiss with no loop yield in between: `trigger_manual_alarm`
+    # is a mock that completes without suspending, so `first` has not unwound.
+    alarm.find_alarm_event_id = AsyncMock(side_effect=asyncio.Event().wait)
+    await switch.async_turn_on()
+    assert not (switch._lookup is not None and switch._lookup.dismissal_requested)
+    await switch.async_turn_off()
+
+    second = switch._lookup
+    assert second is not None and second.dismissal_requested
+
+    # The displaced lookup's own dismissal was cancelled mid-request, so it is
+    # genuinely lost and must be reported — exactly once, by the task that held it.
+    with caplog.at_level(logging.WARNING):
+        await asyncio.gather(first, return_exceptions=True)
+
+    assert _warnings(caplog) == [_unsent_warning()]
+    # ...and cycle 2's obligation is untouched by cycle 1 unwinding.
+    assert switch._lookup is second
+    assert second.dismissal_requested and not second.dismissal_settled
+
+    switch._cancel_event_id_lookup(settled=True)
+    await asyncio.gather(*_tasks(switch), return_exceptions=True)
+
+
+async def test_teardown_during_an_in_flight_dismissal_still_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The other side of the same coin: here the alarm really is left live."""
+    switch, alarm = _make_switch("PANIC")
+    await _park_in_flight_dismissal(switch, alarm)
+
+    with caplog.at_level(logging.WARNING):
+        await switch.async_will_remove_from_hass()
+
+    # Exactly one: the report lives only in the owning task's `finally`, so a
+    # single abandoned dismissal produces a single warning however it was killed.
+    assert _warnings(caplog) == [_unsent_warning()]
+
+
+async def test_second_dismiss_during_an_in_flight_dismissal_does_not_duplicate_it() -> (
+    None
+):
+    """A second `turn_off` must ride the same obligation, not mint a new one.
+
+    The obligation is already outstanding and its request already on the wire.
+    Replacing it would strand the original — the earlier shape of this bug —
+    and re-sending would POST the same dismissal twice.
+    """
+    switch, alarm = _make_switch("PANIC")
+    task = await _park_in_flight_dismissal(switch, alarm)
+    outstanding = switch._lookup
+
+    await switch.async_turn_off()
+
+    assert switch._lookup is outstanding
+    assert _dismiss_mock(switch).await_count == 1
+    switch._cancel_event_id_lookup(settled=True)
+    await asyncio.gather(task, return_exceptions=True)
+
+
+async def test_retrigger_over_a_deferred_dismissal_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dropping a dismissal the user asked for cannot be silent."""
+    switch, alarm = _make_switch("PANIC")
+    alarm.find_alarm_event_id = AsyncMock(side_effect=asyncio.Event().wait)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+    assert switch._lookup is not None and switch._lookup.dismissal_requested
+
+    first = _tasks(switch)[0]
+    with caplog.at_level(logging.WARNING):
+        await switch.async_turn_on()
+        # The report comes from the abandoned task's own unwind, not from the
+        # re-trigger — that is what makes it exactly-once by construction.
+        await asyncio.gather(first, return_exceptions=True)
+
+    assert _warnings(caplog) == [_unsent_warning()]
+    # The re-trigger started a second lookup that will never resolve on its own.
+    switch._cancel_event_id_lookup(settled=True)
+    await asyncio.gather(*_tasks(switch), return_exceptions=True)
+
+
+async def test_dismiss_inside_the_lookup_window_is_deferred_not_dropped() -> None:
+    """Backgrounding the lookup must not break dismissal.
+
+    A dismissal issued inside the resolution window finds `_timeline_id` unset —
+    and this is the *common* case, not an edge one: Abode typically needs
+    30-60s to expose the event. Blocking `turn_off` until it resolves would
+    hold the `PARALLEL_UPDATES = 1` slot and delay the next alarm trigger, so
+    the dismissal rides on the lookup instead. What it must never do is what
+    the old `if self._timeline_id:` guard did: nothing at all, silently,
+    leaving a live alarm in Abode.
+    """
+    switch, alarm = _make_switch("PANIC")
+    release = asyncio.Event()
+
+    async def _slow_lookup() -> str:
+        await release.wait()
+        return "tl_1"
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_slow_lookup)
+
+    await switch.async_turn_on()
+
+    # Returns promptly rather than waiting out the lookup.
+    await asyncio.wait_for(switch.async_turn_off(), timeout=1)
+    assert switch.is_on is False
+    _dismiss_mock(switch).assert_not_awaited()
+
+    release.set()
+    await asyncio.gather(*_tasks(switch))
+
+    _dismiss_mock(switch).assert_awaited_once_with("tl_1")
+    # Spent on the dismissal, not stored for a second one.
+    assert switch._timeline_id is None
+
+
+async def test_deferred_dismissal_failure_is_logged_not_raised(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The deferred dismissal runs detached, so it has no caller to raise to."""
+    switch, alarm = _make_switch("PANIC")
+    release = asyncio.Event()
+
+    async def _slow_lookup() -> str:
+        await release.wait()
+        return "tl_1"
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_slow_lookup)
+    _dismiss_mock(switch).side_effect = AbodeException((500, "boom"))
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+
+    release.set()
+    with caplog.at_level(logging.ERROR):
+        await asyncio.gather(*_tasks(switch))
+
+    matches = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.ERROR
+        and "PANIC" in record.getMessage()
+        and "Deferred dismissal" in record.getMessage()
+    ]
+    assert len(matches) == 1, [r.getMessage() for r in caplog.records]
+
+
+async def test_cancelling_an_in_flight_deferred_dismissal_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A reload landing mid-dismissal leaves the alarm live — say so.
+
+    `except Exception` cannot see this: `CancelledError` is a `BaseException`,
+    which is why the report hangs off the task's `finally` rather than a handler.
+    """
+    switch, alarm = _make_switch("PANIC")
+    task = await _park_in_flight_dismissal(switch, alarm)
+
+    with caplog.at_level(logging.WARNING):
+        switch._cancel_event_id_lookup()
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert task.cancelled()
+    assert _warnings(caplog) == [_unsent_warning()]
+
+
+async def test_deferred_dismissal_warns_when_no_event_id_ever_resolves(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The alarm stays live in Abode — that cannot be silent."""
+    switch, alarm = _make_switch("PANIC")
+    release = asyncio.Event()
+
+    async def _slow_lookup() -> None:
+        await release.wait()
+        return None
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_slow_lookup)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+
+    release.set()
+    with caplog.at_level(logging.WARNING):
+        await asyncio.gather(*_tasks(switch))
+
+    _dismiss_mock(switch).assert_not_awaited()
+    matches = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+        and "PANIC" in record.getMessage()
+        and "was not sent" in record.getMessage()
+    ]
+    assert len(matches) == 1, [r.getMessage() for r in caplog.records]
+
+
+async def test_dismiss_without_an_event_id_or_lookup_is_logged_not_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`if self._timeline_id:` used to swallow this outright.
+
+    Reporting the switch off while the alarm is still live in Abode is a
+    security path, so the failure has to be visible somewhere. With no lookup
+    in flight there is nothing left to defer the dismissal onto.
+    """
+    switch, _ = _make_switch("PANIC")
+    switch._attr_is_on = True
+
+    with caplog.at_level(logging.WARNING):
+        await switch.async_turn_off()
+
+    _dismiss_mock(switch).assert_not_awaited()
+    assert switch.is_on is False
+    matches = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+        and "PANIC" in record.getMessage()
+        and "nothing was dismissed" in record.getMessage()
+    ]
+    assert len(matches) == 1, [r.getMessage() for r in caplog.records]
+
+
+async def test_alarm_end_event_cancels_the_pending_lookup() -> None:
+    """The alarm is over: a deferred dismissal would target a finished event."""
+    switch, alarm = _make_switch("PANIC")
+    alarm.find_alarm_event_id = AsyncMock(side_effect=asyncio.Event().wait)
+
+    await switch.async_turn_on()
+    await switch.async_turn_off()
+    assert switch._lookup is not None and switch._lookup.dismissal_requested
+
+    task = _tasks(switch)[0]
+    switch._alarm_end_callback({"event_code": "3120"})
+
+    assert not (switch._lookup is not None and switch._lookup.dismissal_requested)
+    await asyncio.gather(task, return_exceptions=True)
+    assert task.cancelled()
+
+
+async def test_failed_retrigger_keeps_the_previous_event_id() -> None:
+    """A live alarm must not lose the only ID that can dismiss it.
+
+    `_timeline_id` is cleared before the POST so a SocketIO event landing
+    mid-flight wins. When the POST then fails, nothing superseded the alarm
+    already being tracked, and its SocketIO ALARM event will not fire twice.
+    """
+    switch, alarm = _make_switch("PANIC")
+    await switch.async_turn_on()
+    await asyncio.gather(*_tasks(switch))
+    assert switch._timeline_id == "tl_1"
+
+    alarm.trigger_manual_alarm.side_effect = AbodeException((500, "boom"))
+    with pytest.raises(AbodeException):
+        await switch.async_turn_on()
+
+    assert switch._timeline_id == "tl_1"
+
+
+async def test_teardown_warns_when_the_lookup_will_not_unwind(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The 5s backstop is not expected to fire, but has to be diagnosable.
+
+    A task that outlives its entity will raise on its next state write against a
+    removed one, with nothing connecting the two.
+    """
+    switch, alarm = _make_switch("PANIC")
+    release = asyncio.Event()
+
+    async def _ignores_cancellation() -> None:
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.Event().wait()
+        await release.wait()
+
+    alarm.find_alarm_event_id = AsyncMock(side_effect=_ignores_cancellation)
+    monkeypatch.setattr(switch_module, "EVENT_ID_TASK_TEARDOWN_SECONDS", 0.01)
+
+    await switch.async_turn_on()
+    await asyncio.sleep(0)
+
+    with caplog.at_level(logging.WARNING):
+        await switch.async_will_remove_from_hass()
+
+    assert any("did not unwind" in message for message in _warnings(caplog))
+
+    release.set()
+    await asyncio.gather(*_tasks(switch), return_exceptions=True)
+
+
+async def test_failed_retrigger_reports_the_lookup_it_could_not_restore(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The ID can be put back; the cancelled lookup cannot.
+
+    A 429 on a re-trigger inside the resolution window leaves the *earlier*
+    alarm live with no id and nothing still looking for one. Without this the
+    loss is invisible until someone tries to dismiss.
+    """
+    switch, alarm = _make_switch("PANIC")
+    alarm.find_alarm_event_id = AsyncMock(side_effect=asyncio.Event().wait)
+
+    await switch.async_turn_on()
+    assert switch._timeline_id is None
+
+    alarm.trigger_manual_alarm.side_effect = AbodeException((429, "slow down"))
+    with caplog.at_level(logging.WARNING), pytest.raises(AbodeException):
+        await switch.async_turn_on()
+
+    assert any("no id to dismiss it" in message for message in _warnings(caplog))
+    await asyncio.gather(*_tasks(switch), return_exceptions=True)
+
+
+async def test_a_lookup_that_never_started_is_not_left_behind() -> None:
+    """A stranded `_lookup` would promise dismissals nothing can send.
+
+    Defensive: task creation cannot realistically fail on a running loop. But a
+    non-None `_lookup` with no task would make `async_turn_off` defer forever and
+    `was_resolving` claim a lookup ran.
+    """
+    switch, _ = _make_switch("PANIC")
+
+    def _fail(target: Any, name: str, eager_start: bool = True) -> Any:
+        del name, eager_start
+        # Close it, or the unconsumed coroutine surfaces later as an unrelated
+        # test's "never awaited" warning.
+        target.close()
+        raise RuntimeError("no loop")
+
+    hass = cast(_FakeHass, switch.hass)
+    hass.async_create_background_task = _fail  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        await switch.async_turn_on()
+
+    assert switch._lookup is None
+
+
+async def test_pending_lookup_is_cancelled_on_removal() -> None:
+    """A background task outliving its entity is a leak (and a stale write)."""
+    switch, alarm = _make_switch("PANIC")
+    alarm.find_alarm_event_id = AsyncMock(side_effect=asyncio.Event().wait)
+
+    await switch.async_turn_on()
+    task = _tasks(switch)[0]
+
+    await switch.async_will_remove_from_hass()
+
+    assert task.cancelled()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -459,11 +459,21 @@ async def test_manual_alarm_switch_turn_on(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        with patch(
-            "custom_components.abode_security.abode.devices.alarm.Alarm.trigger_manual_alarm",
-            new_callable=AsyncMock,
-        ) as mock_trigger:
-            mock_trigger.return_value = {"event_id": "test_event_123"}
+        # `find_alarm_event_id` is stubbed too: the switch now resolves the
+        # timeline event id in a background task, and the real lookup would
+        # poll the mock server for ~67s after the service call has returned.
+        with (
+            patch(
+                "custom_components.abode_security.abode.devices.alarm.Alarm.trigger_manual_alarm",
+                new_callable=AsyncMock,
+            ) as mock_trigger,
+            patch(
+                "custom_components.abode_security.abode.devices.alarm.Alarm.find_alarm_event_id",
+                new_callable=AsyncMock,
+                return_value="test_event_123",
+            ),
+        ):
+            mock_trigger.return_value = {"code": 200}
             await hass.services.async_call(
                 SWITCH_DOMAIN,
                 SERVICE_TURN_ON,


### PR DESCRIPTION
## Summary

- `trigger_manual_alarm` returns as soon as the POST is confirmed; the ~67s timeline poll moves to `Alarm.find_alarm_event_id`, run as a background task by the manual alarm switch. Notification latency drops from 30-70s to roughly one round-trip.
- A `switch.turn_off` inside the resolution window no longer silently no-ops: the dismissal is recorded as owed on the lookup and sent when the ID lands.
- Both dismissal paths reconcile against the event they actually dismissed, so a newer alarm arriving mid-request stays live and dismissable.

## Root cause

`Alarm.trigger_manual_alarm` polled the timeline for the event ID **inline**, after the POST had already raised the alarm and notified monitoring. `timeline_event_retry_delays` sums to 67s, and Abode does not expose a triggered alarm on the timeline for 30-60s. Everything downstream — `AbodeManualAlarmSwitch.async_turn_on`, `_execute_action`'s `blocking=True` arm, and therefore the `abode_security.action_triggered` event that drives the user's notification — waited it out.

The event ID had exactly one consumer (`switch.py`). `services.py` and `alarm_control_panel.py` discard the return value, so they paid the 67s for nothing and get the latency fix for free.

## Design notes

Backgrounding the lookup put **dismissal** at risk, and that is where most of the work went.

- Waiting for the ID in `async_turn_off` would be the wrong trade twice over: the poll usually needs the full 30-60s, and `PARALLEL_UPDATES = 1` means a blocked `turn_off` serializes the `switch.turn_on` that raises the *next* alarm — reintroducing the exact latency this fixes.
- The obligation is an `_EventIdLookup` **handed to the task that performs it**, not entity state a later alarm cycle can overwrite. The task reports an unsent dismissal from its own `finally`, so "an abandoned dismissal is reported exactly once" holds by construction. An earlier revision spread this across three booleans read from three sites; it was replaced because each fix kept exposing another instance of the same bug class.
- Targeting is deliberate, because `dismiss_timeline_event` ignores one *specific* event. The polled ID wins; `_timeline_id` is the fallback only for an empty poll, and is withdrawn when another ALARM event arrives after the dismissal was asked for. Failing to dismiss is loud and recoverable; silently ignoring an alarm nobody has seen is not.

Design rationale is in [`docs/ARCHITECTURE.md`](../blob/fix/194/docs/ARCHITECTURE.md) under "Event-ID resolution and deferred dismissal".

## Known limits (filed, not guessed at)

Both recorded in `features/pending.md`; neither is resolvable without a live panel:

- `_find_timeline_alarm_event`'s backward recency window is a flat 90s, so a second alarm raised while the first is still surfacing can be handed the first one's ID. The forward bound is what does the safety work.
- The tree holds two conflicting accounts of whether Abode's dismissal is per-event (`POST timeline_ignore_alarm/<id>`) or panel-wide (`_alarm_end_callback`'s pre-existing comment). Which one is true changes how conservative the deferred path needs to be.

## Test plan

- [x] Added tests that reproduce the bug; verified failing before the fix, passing after
- [x] 32 new tests over trigger, deferral, supersession, settlement, cancellation, teardown and failure paths
- [x] Full suite passes: 782 unit tests, ruff, ruff format, mypy, pyright — `./scripts/check.sh` exit 0
- [x] Warning count unchanged vs `main` (6), verified by stashing
- [x] No uncovered lines in the new code

Fixes #194
