### PR TITLE
test(actions): pin the close-transition contract from #149

### DIFF
--- a/tests/test_action_trigger.py
+++ b/tests/test_action_trigger.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant, ServiceCall
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
@@ -153,7 +153,7 @@ class TestStateChangeHandling:
         coordinator = ActionTriggerCoordinator(hass, manager)
         await coordinator.async_start()
 
-        await manager.async_create(
+        action = await manager.async_create(
             name="Test",
             modes=["home"],
             sensor_entity_ids=["binary_sensor.door"],
@@ -168,7 +168,10 @@ class TestStateChangeHandling:
         hass.states.async_set("binary_sensor.door", "off")
         await hass.async_block_till_done()
 
-        # Should not raise error
+        updated = await manager.async_get(action.id)
+        assert updated is not None
+        assert updated.trigger_count == 0
+
         await coordinator.async_stop()
 
     async def test_coordinator_matches_sensor_and_mode(self, hass) -> None:
@@ -1347,6 +1350,161 @@ class TestStateTransitionRegressions:
         await async_fire_time_changed_and_wait(hass, timedelta(seconds=6))
 
         assert service_calls == []
+
+        await coordinator.async_stop()
+
+
+@pytest.mark.usefixtures("mock_abode", "setup_coordinator")
+class TestCloseTransitionNeverTriggers:
+    """A sensor returning to its resting state must not fire an action.
+
+    Issue #149's scenario: arm home on a hot summer night with a bedroom
+    window open, then close that window hours later when it gets chilly.
+    The close is an `on` -> `off` transition and has to be inert, while the
+    *next* open is a genuine activation and still has to fire. The
+    open-before-arming ordering matters — the sensor is already `on` when the
+    mode changes, so nothing in the sequence looks like a fresh activation
+    until the window is opened again.
+
+    Scoped to the transition guard. A sensor that closes *during* an action's
+    delay window is deliberately not covered: `_delayed_execute` re-checks the
+    action and the mode but never re-reads the sensor, so that action still
+    fires — an intruder closing the window behind them does not call the
+    alarm off.
+    """
+
+    WINDOW = "binary_sensor.bedroom_window"
+    ATTRS = {"friendly_name": "Bedroom Window", "device_class": "window"}
+
+    @staticmethod
+    def _listen(hass) -> tuple[list[ServiceCall], list[Event]]:
+        """Record `switch.turn_on` calls and `action_triggered` events."""
+        switch_calls: list[ServiceCall] = []
+        events: list[Event] = []
+
+        async def mock_service(call):
+            switch_calls.append(call)
+
+        hass.services.async_register("switch", "turn_on", mock_service)
+        hass.bus.async_listen(
+            "abode_security.action_triggered", lambda e: events.append(e)
+        )
+        return switch_calls, events
+
+    async def _arm_home_over_an_open_window(self, hass, manager):
+        """Open the window, then arm home over it — the #149 starting state."""
+        # Sensor state first, so `async_create` resolves a real entity the way
+        # it would in an install where the user picks the sensor from a list.
+        hass.states.async_set(self.WINDOW, "on", self.ATTRS)
+        await hass.async_block_till_done()
+
+        action = await manager.async_create(
+            name="Bedroom Window",
+            modes=["home"],
+            sensor_entity_ids=[self.WINDOW],
+            alarm_entity_ids=["switch.panic_alarm"],
+        )
+
+        hass.states.async_set("alarm_control_panel.abode_alarm", "armed_home")
+        await hass.async_block_till_done()
+        return action
+
+    async def test_close_of_window_open_since_arming_does_not_trigger(
+        self, hass
+    ) -> None:
+        """Closing a window that was already open at arming fires nothing."""
+        manager = _get_manager(hass)
+        coordinator = ActionTriggerCoordinator(hass, manager)
+        await coordinator.async_start()
+
+        switch_calls, events = self._listen(hass)
+        action = await self._arm_home_over_an_open_window(hass, manager)
+
+        # Middle of the night: the window is closed.
+        hass.states.async_set(self.WINDOW, "off", self.ATTRS)
+        await hass.async_block_till_done()
+
+        assert switch_calls == []
+        assert events == []
+        updated = await manager.async_get(action.id)
+        assert updated is not None
+        assert updated.trigger_count == 0
+        assert updated.last_triggered is None
+
+        await coordinator.async_stop()
+
+    async def test_reopening_after_a_close_still_triggers(self, hass) -> None:
+        """The close arms nothing, but re-opening the window still fires."""
+        manager = _get_manager(hass)
+        coordinator = ActionTriggerCoordinator(hass, manager)
+        await coordinator.async_start()
+
+        switch_calls, events = self._listen(hass)
+        action = await self._arm_home_over_an_open_window(hass, manager)
+
+        hass.states.async_set(self.WINDOW, "off", self.ATTRS)
+        await hass.async_block_till_done()
+        assert events == []
+
+        # Same night, later: the window is opened again. That *is* an
+        # activation — the close must not have left the sensor latched shut.
+        hass.states.async_set(self.WINDOW, "on", self.ATTRS)
+        await hass.async_block_till_done()
+
+        assert len(switch_calls) == 1
+        assert switch_calls[0].data["entity_id"] == "switch.panic_alarm"
+        assert len(events) == 1
+        assert events[0].data["triggered_by"] == self.WINDOW
+        assert events[0].data["previous_state"] == "off"
+        assert events[0].data["new_state"] == "on"
+
+        updated = await manager.async_get(action.id)
+        assert updated is not None
+        assert updated.trigger_count == 1
+
+        await coordinator.async_stop()
+
+    async def test_open_close_reopen_fires_once_per_open(self, hass) -> None:
+        """Across a full cycle, only the two opens count as activations."""
+        # The fixture's 0.1s debounce is there to swallow sensor chatter; a
+        # real open/close/re-open cycle is minutes apart, so take it out of
+        # the picture rather than have it decide this assertion.
+        hass.data[DOMAIN]["config"]["debounce_seconds"] = 0
+
+        manager = _get_manager(hass)
+        coordinator = ActionTriggerCoordinator(hass, manager)
+        await coordinator.async_start()
+
+        switch_calls, events = self._listen(hass)
+
+        hass.states.async_set(self.WINDOW, "off", self.ATTRS)
+        await hass.async_block_till_done()
+
+        action = await manager.async_create(
+            name="Bedroom Window",
+            modes=["home"],
+            sensor_entity_ids=[self.WINDOW],
+            alarm_entity_ids=["switch.panic_alarm"],
+        )
+        hass.states.async_set("alarm_control_panel.abode_alarm", "armed_home")
+        await hass.async_block_till_done()
+
+        hass.states.async_set(self.WINDOW, "on", self.ATTRS)
+        await hass.async_block_till_done()
+        assert len(events) == 1
+
+        hass.states.async_set(self.WINDOW, "off", self.ATTRS)
+        await hass.async_block_till_done()
+        assert len(events) == 1
+
+        hass.states.async_set(self.WINDOW, "on", self.ATTRS)
+        await hass.async_block_till_done()
+        assert len(events) == 2
+
+        assert len(switch_calls) == 2
+        updated = await manager.async_get(action.id)
+        assert updated is not None
+        assert updated.trigger_count == 2
 
         await coordinator.async_stop()
 

--- a/tests/test_socketio_push.py
+++ b/tests/test_socketio_push.py
@@ -533,3 +533,122 @@ async def test_disconnect_mid_emit_does_not_lose_subsequent_events(
             ),
             message="device.update push lost after reconnect",
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: issue #149 — a close push must not trigger an action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_close_is_inert_but_reopen_still_triggers(
+    hass: HomeAssistant, mock_server_client: dict[str, str]
+) -> None:
+    """Issue #149, end to end over the real push path.
+
+    The full sequence the user reported, driven entirely by mock pushes:
+
+      1. Open the window while disarmed (hot summer night).
+      2. Arm home *over* the already-open contact.
+      3. Close the window hours later — status Open -> Closed.
+      4. Open it again, still armed.
+
+    Step 3 has to be inert. The coordinator's guard only admits `off` -> `on`,
+    so this test's real job is the layer underneath it: that an Abode
+    ``status: Closed`` refresh drives `binary_sensor.front_door` straight to
+    STATE_OFF without a transient `off` -> `on` blip that would look like an
+    activation. Step 4 then re-opens the window to prove the close didn't
+    latch the sensor shut and a genuine activation still fires.
+    """
+    mock_url = mock_server_client["base_url"]
+    async with (
+        _abode_integration_setup(hass, mock_server_client) as config_entry,
+        aiohttp.ClientSession() as session,
+    ):
+        await _wait_for_socketio_connected(hass, config_entry)
+
+        events: list[Event] = []
+        hass.bus.async_listen(
+            "abode_security.action_triggered", lambda e: events.append(e)
+        )
+
+        # Notification-only action so the assertion is about the trigger
+        # decision, not about arming a switch.
+        manager = hass.data[DOMAIN]["action_manager"]
+        action = await manager.async_create(
+            name="Front window while home",
+            modes=["home"],
+            sensor_entity_ids=[FRONT_DOOR_ENTITY_ID],
+            alarm_entity_ids=[],
+        )
+
+        # 1. Window opened while the system is still disarmed.
+        await _put_device(session, mock_url, FRONT_DOOR_DEVICE_ID, {"status": "Open"})
+        await _emit(
+            session, mock_url, "com.goabode.device.update", FRONT_DOOR_DEVICE_ID
+        )
+        await _wait_for(
+            hass,
+            lambda: (
+                (s := hass.states.get(FRONT_DOOR_ENTITY_ID)) is not None
+                and s.state == STATE_ON
+            ),
+            message=f"{FRONT_DOOR_ENTITY_ID} never transitioned to STATE_ON",
+        )
+
+        # 2. Arm home over the open contact.
+        await _emit(session, mock_url, "com.goabode.gateway.mode", "home")
+        await _wait_for(
+            hass,
+            lambda: (
+                (s := hass.states.get(ALARM_ENTITY_ID)) is not None
+                and s.state == AlarmControlPanelState.ARMED_HOME
+            ),
+            message=f"{ALARM_ENTITY_ID} never transitioned to ARMED_HOME",
+        )
+        assert events == []
+
+        # 3. Middle of the night: the window is closed.
+        await _put_device(session, mock_url, FRONT_DOOR_DEVICE_ID, {"status": "Closed"})
+        await _emit(
+            session, mock_url, "com.goabode.device.update", FRONT_DOOR_DEVICE_ID
+        )
+        await _wait_for(
+            hass,
+            lambda: (
+                (s := hass.states.get(FRONT_DOOR_ENTITY_ID)) is not None
+                and s.state == STATE_OFF
+            ),
+            message=f"{FRONT_DOOR_ENTITY_ID} never transitioned to STATE_OFF",
+        )
+        await hass.async_block_till_done()
+
+        assert events == []
+        stored = await manager.async_get(action.id)
+        assert stored is not None
+        assert stored.trigger_count == 0
+
+        # 4. Opened again while still armed — that one is a real activation.
+        await _put_device(session, mock_url, FRONT_DOOR_DEVICE_ID, {"status": "Open"})
+        await _emit(
+            session, mock_url, "com.goabode.device.update", FRONT_DOOR_DEVICE_ID
+        )
+        await _wait_for(
+            hass,
+            lambda: len(events) >= 1,
+            message="re-opening the window fired no action_triggered event",
+        )
+        await hass.async_block_till_done()
+
+        # Exactly one — `>=` above so a double-fire fails on the count below
+        # with the real reason rather than timing out on an equality predicate
+        # it can never satisfy.
+        assert len(events) == 1
+        assert events[0].data["triggered_by"] == FRONT_DOOR_ENTITY_ID
+        assert events[0].data["previous_state"] == STATE_OFF
+        assert events[0].data["new_state"] == STATE_ON
+        assert events[0].data["mode"] == "home"
+
+        stored = await manager.async_get(action.id)
+        assert stored is not None
+        assert stored.trigger_count == 1


### PR DESCRIPTION
## Summary

- Pins the contract from #149: a sensor going back to its resting state is not an activation, so arming home over an already-open window and closing that window hours later triggers nothing — while the next open still fires.
- Three coordinator-level tests cover the open-at-arm-time / close / re-open sequence, plus a full open → close → re-open cycle.
- One end-to-end test drives the same sequence through real `com.goabode.device.update` and `com.goabode.gateway.mode` pushes against the mock server, so the Abode `Open`/`Closed` status mapping is pinned too, not just the Home Assistant state guard.
- No production code changes.

## Root cause

There isn't one — the behaviour was already correct, and this PR is the "make sure" the issue asked for.

`ActionTriggerCoordinator._handle_state_change` only admits `off` -> `on`, so a close (`on` -> `off`) never reaches `_process_sensor_activation`, and arming over an already-open sensor produces no transition at all. That contract was documented (`docs/ARCHITECTURE.md`) but only half-covered by tests: the sibling `unavailable`/`unknown` cases had real regression tests, while the close case rested on `test_coordinator_ignores_off_state`, which had no assertions and ended on a bare `# Should not raise error`. That test now asserts `trigger_count == 0`.

Nothing under the coordinator can turn a close into an activation either — the SocketIO `device.update` path refreshes the device in place and writes `Closed` straight through to `STATE_OFF`, with no transient `off` -> `on` blip. The integration test pins that layer.

## Test plan

- [x] Three coordinator tests + one end-to-end SocketIO test added
- [x] Mutation-checked: loosening the transition guard to accept any state change fails all three new tests, the strengthened `test_coordinator_ignores_off_state`, and the integration test; all pass against the real guard
- [x] `./scripts/check.sh` — 812 passed
- [x] Integration tier — 118 passed (mock server run outside Docker locally)

## Out of scope

A sensor that closes *during* an action's delay window does not cancel it: `_delayed_execute` re-checks the action and the mode but never re-reads the sensor. Read as intended — an intruder closing the window behind them shouldn't call off the alarm — and now stated in the test class docstring so a future reader doesn't assume this class covers it.

Fixes #149
