### PR TITLE
fix(binary-sensor): stop offline sensors reading as clear

### DIFF
--- a/custom_components/abode_security/abode/UPSTREAM.md
+++ b/custom_components/abode_security/abode/UPSTREAM.md
@@ -20,6 +20,29 @@ These changes are deliberate and must not be reverted by a sync:
 - `keyring`-based credential persistence removed — HA owns config storage.
 - Synchronous HTTP (`requests`) replaced with `aiohttp.ClientSession`.
 - `lomond` WebSocket transport replaced with `aiohttp.ClientWebSocketResponse` (issue #61, Phase 3). SocketIO daemon thread folded into the HA event loop.
+- `devices/binary_sensor.py` status mapping (issue #210):
+  - `BinarySensor.is_reporting` added. Upstream has no per-device liveness
+    signal, so `Offline` was folded into `is_on` as "clear" and a stale status
+    read as a closed door. The HA entity uses this for per-device availability.
+    A `no_response` fault counts as not-reporting too, deliberately: it means
+    the panel has stopped hearing from the device, so its status is stale for
+    the same reason.
+  - `_LINK_STATE_TAGS` added, with `Connectivity.is_reporting` overriding for
+    those tags. `glass`, `keypad`, `remote_controller`, `siren` and `bx` report
+    `Online` as their steady state and deliver events over the timeline, so
+    `Offline` is their reading rather than a stale status. The override is
+    keyed on tag, not on the class, because upstream overloads `Connectivity`:
+    `water_sensor` reports `On`/`Off` for moisture, and `smoke_detector` /
+    `fix_panic` have no upstream mock to check, so those three keep the
+    staleness treatment.
+  - `BinarySensor.is_on` returns `False` for a missing or empty `status`.
+    Upstream's `get_value` returns `{}` for an absent key, and
+    `{} not in (...)` is `True`, so a device doc without a `status` field read
+    as active.
+  - `Motion.is_on` compares `Occupancy` status with `not in (STATUS.ONLINE,
+    STATUS.OFFLINE)`. Upstream's `not in STATUS.ONLINE` is a substring test
+    against the string `'Online'`, so `On` read as clear and `Offline` read as
+    occupied.
 
 ## Sync policy
 

--- a/custom_components/abode_security/abode/devices/binary_sensor.py
+++ b/custom_components/abode_security/abode/devices/binary_sensor.py
@@ -12,16 +12,62 @@ class BinarySensor(base.Device):
         """
         Get sensor state.
 
-        Assume offline or open (worst case).
+        Reports the last known status. A status the device never sent (missing
+        or empty) is not evidence of activity, and neither is it evidence of
+        "clear" — ``is_reporting`` is what tells the two apart.
         """
+        if not self.status:
+            return False
         return self.status not in (
             STATUS.OFF,
             STATUS.OFFLINE,
             STATUS.CLOSED,
         )
 
+    @property
+    def is_reporting(self):
+        """
+        Whether the device is currently reporting its own state.
+
+        A sensor that has dropped off the RF network keeps the last status it
+        managed to send, so ``Offline`` (or a ``no_response`` fault) means that
+        status is stale — not that the door is closed. Callers surface this as
+        unavailable rather than letting stale state read as "clear", which is
+        what turned an offline blip on an open window into a spurious
+        "off" -> "on" activation (issue #210).
+        """
+        return (
+            bool(self.status)
+            and self.status != STATUS.OFFLINE
+            and not self.no_response
+        )
+
+
+#: Tags whose steady-state status is `Online` and whose real events arrive over
+#: the timeline rather than through device status. For these `Offline` is the
+#: reading itself — they surface with the `connectivity` device class, where
+#: `off` renders as "Disconnected" — so withholding it as `unavailable` would
+#: erase the only state the entity exists to report.
+#:
+#: The rest of `Connectivity`'s tags are not like this: `water_sensor` reports
+#: `On`/`Off` for moisture, and `smoke_detector`/`fix_panic` are unverified
+#: against a real device. Those carry a payload an offline blip must not be
+#: allowed to fake, so they take the staleness treatment (issue #210).
+_LINK_STATE_TAGS = frozenset(
+    f'device_type.{tag}'
+    for tag in ('glass', 'keypad', 'remote_controller', 'siren', 'bx')
+)
+
 
 class Connectivity(BinarySensor):
+    """Upstream's catch-all for sensors that report `Online` — plus moisture.
+
+    The class is overloaded: most of these tags report their link to the panel
+    as their status, but `water_sensor` (and possibly `smoke_detector` /
+    `fix_panic`) report a real payload. `is_reporting` splits them by tag
+    rather than by class for that reason.
+    """
+
     tags = (
         'glass',
         'keypad',
@@ -35,6 +81,13 @@ class Connectivity(BinarySensor):
         'smoke_detector',
     )
 
+    @property
+    def is_reporting(self):
+        """Report always for the tags whose `Offline` is the reading itself."""
+        if str(self.get_value('type_tag')).lower() in _LINK_STATE_TAGS:
+            return True
+        return super().is_reporting
+
 
 class Motion(BinarySensor):
     tags = (
@@ -45,7 +98,14 @@ class Motion(BinarySensor):
     @property
     def is_on(self):
         if self.type == 'Occupancy':
-            return self.status not in STATUS.ONLINE
+            # `STATUS.ONLINE` is a plain string, so `status not in STATUS.ONLINE`
+            # was a substring test: "On" read as clear and "Offline" read as
+            # occupied. Compare against the statuses themselves, keeping
+            # "Offline" clear like every other sensor type (issue #210).
+            return bool(self.status) and self.status not in (
+                STATUS.ONLINE,
+                STATUS.OFFLINE,
+            )
         return super().is_on
 
 

--- a/custom_components/abode_security/binary_sensor.py
+++ b/custom_components/abode_security/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import cast
 
 from homeassistant.components.binary_sensor import (
@@ -18,6 +19,8 @@ from .entity import AbodeDevice
 from .models import AbodeSystem
 
 PARALLEL_UPDATES = 1
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -48,6 +51,16 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorEntity):
     _attr_name = None
     _device: BinarySensor
 
+    # Last known reporting state, so the log below fires on transitions rather
+    # than on every state sync. `None` until the first sync, which keeps setup
+    # quiet.
+    _was_reporting: bool | None = None
+
+    # The value `_resolve_available` last read off the device, so the log and
+    # the availability actually applied are the same observation rather than
+    # two adjacent reads.
+    _reporting = True
+
     def __init__(self, data: AbodeSystem, device: BinarySensor) -> None:
         """Initialize a binary sensor for an Abode device."""
         # `is_window` / `generic_type` are device-shape signals that don't
@@ -60,7 +73,39 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorEntity):
             )
         super().__init__(data, device)
 
+    def _resolve_available(self) -> bool:
+        """Fold the device's own reporting state into entity availability.
+
+        A sensor that has gone `Offline` (or faulted `no_response`) is holding
+        a stale status. Reporting it as `unavailable` rather than letting that
+        stale status read as `off` is what stops an offline blip on an open
+        window from looking like a fresh `off` -> `on` activation (#210).
+        """
+        self._reporting = cast(bool, self._device.is_reporting)
+        return super()._resolve_available() and self._reporting
+
     def _sync_attrs(self) -> None:
         """Mirror current device state into `_attr_is_on` (plus base attrs)."""
-        super()._sync_attrs()
+        super()._sync_attrs()  # resolves availability, refreshing `_reporting`
         self._attr_is_on = cast(bool, self._device.is_on)
+        self._log_reporting_transition()
+
+    def _log_reporting_transition(self) -> None:
+        """Log when the device starts or stops reporting.
+
+        Making offline sensors unavailable trades a false trigger for possible
+        `unavailable` noise; this line is what makes the real-world frequency
+        of that tradeoff measurable from the HA log. Reads the value
+        `_resolve_available` already resolved, so the logged reason and the
+        availability actually applied can't disagree.
+        """
+        reporting = self._reporting
+        if self._was_reporting is not None and reporting != self._was_reporting:
+            _LOGGER.info(
+                "Abode sensor %s %s reporting (status=%s, no_response=%s)",
+                self._device.name,
+                "resumed" if reporting else "stopped",
+                self._device.status,
+                self._device.no_response,
+            )
+        self._was_reporting = reporting

--- a/custom_components/abode_security/entity.py
+++ b/custom_components/abode_security/entity.py
@@ -29,6 +29,11 @@ class AbodeEntity(Entity):
     _attr_attribution = ATTRIBUTION
     _attr_has_entity_name = True
 
+    # SocketIO connectivity, the only availability signal the base class has.
+    # Assumed up until the connection callback says otherwise, so entities
+    # don't start out unavailable before the first event arrives.
+    _connection_available = True
+
     def __init__(self, data: AbodeSystem) -> None:
         """Initialize Abode entity."""
         self._data = data
@@ -66,9 +71,27 @@ class AbodeEntity(Entity):
             self.unique_id,
         )
 
+    def _resolve_available(self) -> bool:
+        """Resolve availability from every signal this entity tracks.
+
+        Subclasses extend this to fold in per-device signals (e.g. a sensor
+        that has dropped off the RF network). Within `AbodeEntity` and
+        `AbodeDevice` both writers of `_attr_available` — the SocketIO
+        callback and the device-state sync — go through here, so neither can
+        clobber the other's half of the answer (#210).
+
+        `switch.py` predates this and still assigns `_attr_available`
+        directly on its alarm-attached switches, so a CMS switch that marked
+        itself unavailable after repeated poll errors is still reset by the
+        next connection-status callback. Migrating those to an override here
+        would fix that; it is out of scope for #210.
+        """
+        return self._connection_available
+
     def _update_connection_status(self) -> None:
         """Update the entity available property."""
-        self._attr_available = self._data.abode.events.connected
+        self._connection_available = self._data.abode.events.connected
+        self._attr_available = self._resolve_available()
         self.schedule_update_ha_state()
 
 
@@ -123,6 +146,7 @@ class AbodeDevice(AbodeEntity):
             "no_response": self._device.no_response,
             "device_type": self._device.type,
         }
+        self._attr_available = self._resolve_available()
 
     def _update_callback(self, _device: AbodeDev) -> None:
         """Update the device state."""

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -467,6 +467,57 @@ async def entity_action(self):
 
 Callback registration via `hass.async_add_executor_job(...)` is wrapped in `asyncio.wait_for(..., timeout=10.0)`; timeouts are treated as non-fatal (polling continues). See `ASYNC_AWAIT_PATTERNS.md` for rationale and call sites.
 
+### Entity Availability Composition
+
+Within `AbodeEntity` / `AbodeDevice`, `_attr_available` has two writers — the
+SocketIO connection callback and the device-state sync — so both go through
+`AbodeEntity._resolve_available()` instead of assigning the attribute
+directly. Without that single resolution point a SocketIO reconnect would
+silently mark an offline device available again.
+
+(`switch.py`'s alarm-attached switches predate this and still assign
+`_attr_available` directly, so a CMS switch that marks itself unavailable
+after repeated poll errors is reset by the next connection-status callback.
+Known gap, not covered by the hook.)
+
+```python
+class AbodeEntity(Entity):
+    _connection_available = True          # SocketIO half; assumed up until told
+
+    def _resolve_available(self) -> bool:
+        return self._connection_available
+
+class AbodeBinarySensor(AbodeDevice, BinarySensorEntity):
+    def _resolve_available(self) -> bool:
+        return super()._resolve_available() and self._device.is_reporting
+```
+
+Only binary sensors fold in a per-device signal (`#210`). A contact or motion
+sensor that reports `Offline` — or faults `no_response` — is holding a stale
+status, and letting that stale status read as `off` turned an offline blip on
+an open window into a fresh `off` -> `on` activation, which is exactly what
+`ActionTriggerCoordinator._handle_state_change` fires on. Reporting
+`unavailable` instead lands it on the transition the coordinator already
+rejects.
+
+Two deliberate boundaries:
+
+- **Link-state tags are exempt** (`_LINK_STATE_TAGS` in
+  `abode/devices/binary_sensor.py`): `glass`, `keypad`, `remote_controller`,
+  `siren`, `bx`. These report `Online` as their steady state and deliver real
+  events over the timeline, so `Offline` is the reading itself, not staleness
+  — withholding it would erase the only state those entities report. The
+  exemption is keyed on tag rather than on the `Connectivity` class because
+  that class is overloaded: `water_sensor` reports `On`/`Off` for moisture,
+  and `smoke_detector` / `fix_panic` are unverified, so all three take the
+  staleness treatment instead. Those are exactly the sensors a user wires an
+  action to, and `ActionTriggerCoordinator._handle_state_change` does not
+  filter by device class.
+- **Other device platforms are not covered.** Lights, locks, covers, cameras,
+  and sensors keep showing their last known state while offline. The false
+  trigger lives only on the binary-sensor path, so widening it was left out of
+  `#210` rather than silently bundled in.
+
 ### Dual Operation Modes
 
 - **Polling** — `async_update()` on HA's interval (fallback and CMS-settings refresh)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,19 @@
 - Lower the polling interval in the integration options (15–30 s), or rely on event updates.
 - Check Home Assistant system resources.
 
+**A sensor shows `unavailable` instead of `off`**
+- Contact and motion sensors report `unavailable` when the device itself stops
+  reporting — an `Offline` status or a `no_response` fault — because its last
+  known status is stale, not a reading of "closed". Showing it as `off` is what
+  used to let an offline blip on an open window look like a fresh
+  `off` → `on` activation and fire an alarm action.
+- Search the log for `stopped reporting` to see how often it happens and why:
+  `Abode sensor Front Door stopped reporting (status=Offline, no_response=False)`.
+- Frequent flapping usually means a weak RF link or a low battery — check the
+  sensor's distance from the panel, and its `battery_low` attribute while it is
+  reporting (Home Assistant hides entity attributes during the `unavailable`
+  half of a flap).
+
 **Authentication errors**
 - Verify your Abode password.
 - Two-factor authentication is not currently supported.

--- a/features/pending.md
+++ b/features/pending.md
@@ -20,6 +20,22 @@ The review also landed four direct fixes for production bugs (frontend WS contra
       entity_id, which is the most a fire-and-forget path can do. Making the
       service await the entities (or collect results) would close the gap.
 
+- [ ] `Connectivity` is overloaded in the vendored fork, so `water_sensor`,
+      `smoke_detector` and `fix_panic` all resolve to `generic_type`
+      `connectivity` and render with the `connectivity` device class — a
+      moisture sensor shows "Connected"/"Disconnected" rather than
+      "Wet"/"Dry". Splitting them into their own device classes is an upstream
+      shape change beyond #210, which only stopped their offline blips from
+      faking an activation. `smoke_detector` and `fix_panic` also have no
+      upstream mock, so whether they report `Online`/`Offline` or a real
+      payload is unverified against hardware.
+
+- [ ] `switch.py`'s alarm-attached switches assign `_attr_available` directly
+      (7 sites), bypassing `AbodeEntity._resolve_available()`. A CMS switch
+      that marks itself unavailable after repeated poll errors is reset by the
+      next connection-status callback. Migrating them to a `_resolve_available`
+      override with their own poll-health half would close it.
+
 ## Frontend Panel Enhancements
 
 **Source**: Phase 5 & 6 of better-development

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,6 +1,8 @@
 """Tests for the Abode Security binary sensor device."""
 
+import logging
 import os
+from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.components.binary_sensor import (
@@ -15,16 +17,30 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     CONF_PASSWORD,
     CONF_USERNAME,
+    EVENT_STATE_CHANGED,
     STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.abode_security import ATTR_DEVICE_ID
+from custom_components.abode_security.abode.devices.binary_sensor import (
+    BinarySensor,
+    Connectivity,
+    Motion,
+)
+from custom_components.abode_security.binary_sensor import AbodeBinarySensor
 from custom_components.abode_security.const import ATTRIBUTION, CONF_POLLING, DOMAIN
 
 from .common import setup_platform
+
+# The platform module's logger, so the transition-log test asserts against the
+# same logger production writes to.
+_BINARY_SENSOR_LOGGER = "custom_components.abode_security.binary_sensor"
 
 
 async def test_entity_registry(
@@ -152,3 +168,317 @@ async def test_binary_sensor_with_mock_server(
             os.environ["ABODE_BASE_URL"] = original_url
         elif "ABODE_BASE_URL" in os.environ:
             del os.environ["ABODE_BASE_URL"]
+
+
+# --- Regression tests for status → state mapping (issue #210) ---
+
+
+def _make_binary_sensor(
+    cls: type[BinarySensor],
+    status: str | None,
+    *,
+    device_type: str = "Door Contact",
+    no_response: int = 0,
+    tag: str | None = None,
+) -> BinarySensor:
+    """Build a bare vendored device with just the state `is_on` reads."""
+    state: dict[str, object] = {
+        "id": "RF:0000dead",
+        "uuid": "0000dead",
+        "type": device_type,
+        "name": "Test Sensor",
+        "faults": {"no_response": no_response},
+    }
+    # `resolve_class` never runs (the class is instantiated directly), but
+    # `Connectivity.is_reporting` keys off the tag, and keeping it consistent
+    # stops the fixture describing a device shape it isn't. `BinarySensor`
+    # itself declares no tags.
+    if tag or cls.tags:
+        state["type_tag"] = f"device_type.{tag or cls.tags[0]}"
+    if status is not None:
+        state["status"] = status
+    return cls(state, None)
+
+
+def _make_entity(device: BinarySensor) -> AbodeBinarySensor:
+    """Build a binary sensor entity around a vendored device."""
+    data = MagicMock()
+    data.polling = False
+    data.abode.events.connected = True
+    return AbodeBinarySensor(data, device)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_is_on", "expected_is_reporting"),
+    [
+        ("Closed", False, True),
+        ("Open", True, True),
+        ("Off", False, True),
+        ("On", True, True),
+        # An offline sensor keeps its last known status, so it must not read as
+        # "clear" — that is what turned an offline blip on an open window into a
+        # spurious "off" -> "on" activation.
+        ("Offline", False, False),
+        # A device doc without a status field is not evidence of anything.
+        (None, False, False),
+        ("", False, False),
+    ],
+)
+def test_binary_sensor_status_mapping(
+    status: str | None, expected_is_on: bool, expected_is_reporting: bool
+) -> None:
+    """Status maps to `is_on`/`is_reporting` without conflating the two."""
+    device = _make_binary_sensor(BinarySensor, status)
+
+    assert device.is_on is expected_is_on
+    assert device.is_reporting is expected_is_reporting
+
+
+def test_binary_sensor_no_response_fault_is_not_reporting() -> None:
+    """A `no_response` fault means the status is stale even when it looks fine."""
+    device = _make_binary_sensor(BinarySensor, "Open", no_response=1)
+
+    assert device.is_reporting is False
+    # The last known status is still surfaced; availability is what changes.
+    assert device.is_on is True
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_is_on", "expected_is_reporting"),
+    [
+        ("Online", False, True),
+        # `status not in STATUS.ONLINE` was a substring test: every substring of
+        # "Online" read as clear and "Offline" read as occupied.
+        ("On", True, True),
+        ("Offline", False, False),
+        ("", False, False),
+        (None, False, False),
+    ],
+)
+def test_occupancy_status_mapping(
+    status: str | None, expected_is_on: bool, expected_is_reporting: bool
+) -> None:
+    """Occupancy compares against the status, not its characters."""
+    device = _make_binary_sensor(Motion, status, device_type="Occupancy")
+
+    assert device.is_on is expected_is_on
+    assert device.is_reporting is expected_is_reporting
+
+
+def test_motion_non_occupancy_uses_base_mapping() -> None:
+    """A plain motion sensor keeps the shared `BinarySensor` mapping.
+
+    `Online` reading as `is_on` is upstream behaviour preserved deliberately,
+    not a mapping this test claims is correct: motion for these devices
+    arrives over the timeline rather than through device status. Out of scope
+    for #210 — pinned here only so a change to it is a visible edit.
+    """
+    device = _make_binary_sensor(Motion, "Online", device_type="Motion Camera")
+
+    assert device.is_on is True
+
+
+@pytest.mark.parametrize("tag", ["glass", "keypad", "remote_controller", "siren", "bx"])
+@pytest.mark.parametrize(
+    ("status", "expected_is_on"),
+    [("Online", True), ("Offline", False)],
+)
+def test_link_state_tags_report_offline_as_a_state(
+    tag: str, status: str, expected_is_on: bool
+) -> None:
+    """For link-state tags `Offline` is the reading, not a stale status.
+
+    These render with the `connectivity` device class, where `off` means
+    "Disconnected" — the one state they exist to report. Withholding it as
+    `unavailable` (as contacts and motion sensors now do) would erase it.
+    """
+    device = _make_binary_sensor(Connectivity, status, device_type="Keypad", tag=tag)
+
+    assert device.is_reporting is True
+    assert device.is_on is expected_is_on
+
+
+def test_link_state_tag_reports_through_a_no_response_fault() -> None:
+    """The tag exemption wins over the fault: `off` still means Disconnected."""
+    device = _make_binary_sensor(
+        Connectivity, "Offline", device_type="Keypad", tag="keypad", no_response=1
+    )
+
+    assert device.is_reporting is True
+    assert device.is_on is False
+
+
+def test_link_state_entity_stays_available_when_offline() -> None:
+    """The entity for an offline keypad reports `off`, not gone."""
+    entity = _make_entity(
+        _make_binary_sensor(Connectivity, "Offline", device_type="Keypad", tag="keypad")
+    )
+
+    assert entity.available is True
+    assert entity.is_on is False
+
+
+@pytest.mark.parametrize(
+    ("tag", "device_type"),
+    [
+        ("water_sensor", "Water Sensor"),
+        ("smoke_detector", "Smoke Detector"),
+        ("fix_panic", "Panic Button"),
+    ],
+)
+def test_payload_tags_in_connectivity_still_treat_offline_as_stale(
+    tag: str, device_type: str
+) -> None:
+    """`Connectivity` is overloaded; its payload-carrying tags get the fix.
+
+    A water sensor reports `On`/`Off` for moisture, so an offline blip must not
+    read as "dry" — these are exactly the sensors a user wires an action to,
+    and the trigger coordinator does not filter by device class.
+    """
+    device = _make_binary_sensor(
+        Connectivity, "Offline", device_type=device_type, tag=tag
+    )
+
+    assert device.is_reporting is False
+
+
+def test_motion_pir_offline_is_stale() -> None:
+    """A PIR that dropped off the network withholds its status like a contact."""
+    device = _make_binary_sensor(
+        Motion, "Offline", device_type="Motion Camera", tag="pir"
+    )
+
+    assert device.is_reporting is False
+
+
+def test_entity_unavailable_when_device_offline() -> None:
+    """An offline device reports `unavailable`, not `off` (issue #210)."""
+    entity = _make_entity(_make_binary_sensor(BinarySensor, "Offline"))
+
+    assert entity.available is False
+
+
+def test_entity_available_when_device_reporting() -> None:
+    """A reporting device stays available and mirrors its status."""
+    entity = _make_entity(_make_binary_sensor(BinarySensor, "Open"))
+
+    assert entity.available is True
+    assert entity.is_on is True
+
+
+def test_entity_availability_tracks_device_updates() -> None:
+    """Going offline and back flips availability, never `on` -> `off` -> `on`."""
+    device = _make_binary_sensor(BinarySensor, "Open")
+    entity = _make_entity(device)
+    assert entity.available is True
+    assert entity.is_on is True
+
+    device.update({"status": "Offline"})
+    entity._sync_attrs()  # noqa: SLF001 — stands in for the device callback
+    assert entity.available is False
+
+    device.update({"status": "Open"})
+    entity._sync_attrs()  # noqa: SLF001
+    assert entity.available is True
+    assert entity.is_on is True
+
+
+def test_socketio_reconnect_does_not_clobber_device_availability() -> None:
+    """The SocketIO callback must not mark an offline device available again."""
+    entity = _make_entity(_make_binary_sensor(BinarySensor, "Offline"))
+    entity.schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    entity._update_connection_status()  # noqa: SLF001
+
+    assert entity.available is False
+
+
+def test_reporting_transitions_are_logged_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The measurement log fires on transitions only — not on every sync.
+
+    This line is the instrument for judging whether unavailable-on-offline is
+    noisier than the false trigger it removes, so silence on the first sync
+    and on repeated syncs at the same reporting state is the point.
+    """
+    device = _make_binary_sensor(BinarySensor, "Open")
+
+    with caplog.at_level(logging.INFO, logger=_BINARY_SENSOR_LOGGER):
+        entity = _make_entity(device)
+        assert caplog.records == []  # first sync establishes a baseline only
+
+        entity._sync_attrs()  # noqa: SLF001
+        assert caplog.records == []  # unchanged reporting state stays quiet
+
+        device.update({"status": "Offline"})
+        entity._sync_attrs()  # noqa: SLF001
+        assert len(caplog.records) == 1
+        assert "stopped reporting" in caplog.records[0].getMessage()
+
+        entity._sync_attrs()  # noqa: SLF001
+        assert len(caplog.records) == 1  # still offline, still quiet
+
+        device.update({"status": "Open"})
+        entity._sync_attrs()  # noqa: SLF001
+        assert len(caplog.records) == 2
+        assert "resumed reporting" in caplog.records[1].getMessage()
+
+
+def test_connection_loss_marks_reporting_device_unavailable() -> None:
+    """Losing SocketIO still marks a healthy device unavailable."""
+    entity = _make_entity(_make_binary_sensor(BinarySensor, "Open"))
+    entity.schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+    entity._data.abode.events.connected = False  # noqa: SLF001
+
+    entity._update_connection_status()  # noqa: SLF001
+
+    assert entity.available is False
+
+
+def _get_platform_entity(hass: HomeAssistant, entity_id: str) -> AbodeBinarySensor:
+    """Fetch a live platform entity so its device state can be driven."""
+    component = hass.data[DATA_INSTANCES][BINARY_SENSOR_DOMAIN]
+    return next(
+        entity  # type: ignore[misc]
+        for entity in component.entities
+        if entity.entity_id == entity_id
+    )
+
+
+async def test_offline_blip_never_looks_like_a_fresh_activation(
+    hass: HomeAssistant,
+    aiohttp_mock,  # noqa: ARG001
+) -> None:
+    """End-to-end guard for #210, through the real HA state machine.
+
+    The earlier unit tests assert on `entity.available`; this one asserts on
+    what `ActionTriggerCoordinator._handle_state_change` actually reads — the
+    states HA writes. An open window whose contact drops off the RF network
+    must go `on` -> `unavailable` -> `on`, never `on` -> `off` -> `on`, since
+    only the latter is the `off` -> `on` transition that fires an action.
+    """
+    await setup_platform(hass, BINARY_SENSOR_DOMAIN)
+
+    entity = _get_platform_entity(hass, "binary_sensor.front_door")
+    observed: list[str] = []
+
+    def _record(event: Event) -> None:
+        if event.data["entity_id"] == "binary_sensor.front_door":
+            observed.append(event.data["new_state"].state)
+
+    hass.bus.async_listen(EVENT_STATE_CHANGED, _record)
+
+    async def _push_status(status: str) -> None:
+        entity._device.update({"status": status})  # noqa: SLF001
+        entity._update_callback(entity._device)  # noqa: SLF001
+        await hass.async_block_till_done()
+
+    await _push_status("Open")
+    await _push_status("Offline")
+    await _push_status("Open")
+
+    assert observed == [STATE_ON, STATE_UNAVAILABLE, STATE_ON]
+    # The discriminator: before the fix the offline blip wrote "off" here, and
+    # the return to "Open" was then an off -> on activation.
+    assert STATE_OFF not in observed


### PR DESCRIPTION
## Summary

- Offline contact and motion sensors now report `unavailable` instead of `off`, so an offline blip on an open window can no longer look like a fresh `off` → `on` activation and fire an alarm action.
- `Occupancy` sensors compare their status instead of testing it as a substring of `'Online'`, so `On` no longer reads as clear and `Offline` no longer reads as occupied.
- A device document that arrives without a `status` field no longer reads as active.

## Root cause

`BinarySensor.is_on` folded `Offline` in with `Off`/`Closed`, and nothing compensated for it: `AbodeEntity._update_connection_status` drove `_attr_available` from SocketIO connectivity alone, never from a device's own `Offline` status or `no_response` fault. A contact that dropped off the RF network therefore stayed *available* in Home Assistant and simply flipped to `off` — indistinguishable from the window being closed. When it came back reporting `Open`, `ActionTriggerCoordinator._handle_state_change` saw a textbook `off` → `on` transition and triggered.

Separately, `Motion.is_on` used `self.status not in STATUS.ONLINE`. `STATUS.ONLINE` is the plain string `'Online'`, so that was substring containment, not membership: every substring of `"Online"` read as off, and `Offline` read as *detected* — inverting the convention every other sensor type follows.

## Approach

`BinarySensor.is_reporting` is a new per-device liveness signal (false on `Offline`, a `no_response` fault, or a missing/empty status). `AbodeBinarySensor` folds it into availability, which lands the offline blip on the `unavailable` → `on` transition the coordinator already rejects — a path with existing regression coverage in `TestStateTransitionRegressions`.

Both writers of `_attr_available` now go through `AbodeEntity._resolve_available()` so the SocketIO callback and the device-state sync compose rather than clobber each other. Other platforms are unaffected: their resolution is still just the connection flag.

### Which sensors are exempt, and why

`Connectivity` is overloaded upstream, so the exemption is keyed on **tag** rather than on the class. `_LINK_STATE_TAGS` — `glass`, `keypad`, `remote_controller`, `siren`, `bx` — all default to `status=STATUS.ONLINE` in the upstream mocks and deliver their real events over the timeline. For them `Offline` *is* the reading, and they render with the `connectivity` device class where `off` means "Disconnected"; withholding it would erase the only state those entities report.

The rest of `Connectivity` keeps the staleness treatment: `water_sensor` defaults to `status=STATUS.OFF` (a real moisture payload), and `smoke_detector` / `fix_panic` have no upstream mock, so they are unverified against hardware. Those are exactly the sensors a user wires an action to, and `_handle_state_change` does not filter by device class — for an unverified tag, an `unavailable` is the milder failure than a spurious activation.

Scope was kept to binary sensors. Lights, locks, covers, cameras and sensors still show their last known state while offline; the false trigger lives only on the binary-sensor path.

## Tradeoff

Making offline contacts unavailable could be noisier than the false trigger it removes — the issue flags this as worth checking against a real install. Reporting transitions are logged at INFO so the frequency is measurable:

```
Abode sensor Front Door stopped reporting (status=Offline, no_response=False)
```

`docs/troubleshooting.md` has a new entry pointing users at that line.

## Test plan

- [x] Added tests that reproduce both bugs; `Occupancy` had **no** coverage at all before this
- [x] End-to-end guard through the real HA state machine: `test_offline_blip_never_looks_like_a_fresh_activation` asserts HA writes `['on', 'unavailable', 'on']`. Verified as a true discriminator — with the `is_reporting` fold removed it fails with `assert ['on', 'off', 'on'] == ['on', 'unavailable', 'on']`, i.e. exactly the false trigger
- [x] Both halves of the tag split pinned: all five link-state tags × `Online`/`Offline`, plus `water_sensor` / `smoke_detector` / `fix_panic` still treating `Offline` as stale
- [x] Availability composition covered in both directions (SocketIO reconnect cannot revive an offline device; connection loss still marks a healthy one unavailable)
- [x] Transition log asserted to fire once per transition and stay silent on the first sync and on repeated syncs
- [x] Full suite green: 846 passed, plus ruff, ruff format, mypy, pyright

## Notes for the reviewer

The library changes are recorded in `abode/UPSTREAM.md` as intentional divergence (the issue asks for that call), and the availability composition is documented in `docs/ARCHITECTURE.md`.

Two adjacent gaps this deliberately does **not** close, both logged in `features/pending.md`:

1. `Connectivity` also gives moisture/smoke/panic devices the `connectivity` device class, so a water sensor displays "Connected"/"Disconnected" rather than "Wet"/"Dry". That is an upstream shape change beyond this issue.
2. `switch.py` still assigns `_attr_available` directly in seven places, bypassing the new hook — so a CMS switch that marks itself unavailable after repeated poll errors is reset by the next connection-status callback. Pre-existing, not introduced here.

Fixes #210
